### PR TITLE
Configurable currency for self-hosted deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ postgresql://USERNAME:PASSWORD@HOST:PORT/DATABASE
 | `RESEND_API_KEY` | Resend API key for hosted/existing installs | None |
 | `ALLOWED_ORIGINS` | Comma-separated list of allowed CORS origins | Uses `APP_URL` or localhost |
 | `DEPLOYMENT_MODE` | `self-hosted` or `saas` | `self-hosted` |
+| `DEFAULT_CURRENCY` | ISO 4217 currency code used to format bill amounts | `USD` |
+| `DEFAULT_LOCALE` | BCP 47 locale used to format bill amounts | `en-US` |
 | `ENABLE_2FA` | Enable two-factor authentication flows | `false` |
 | `ENABLE_PASSKEYS` | Enable passkey (WebAuthn) support | `false` |
 | `WEBAUTHN_RP_ID` | WebAuthn relying party ID (domain only) | Derived from `APP_URL` |

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -21,6 +21,10 @@ JWT_SECRET_KEY=change-this-to-another-random-64-char-string
 # Deployment mode: 'self-hosted' (default) or 'saas'
 # DEPLOYMENT_MODE=self-hosted
 
+# Currency and locale used to format bill amounts in the web application
+# DEFAULT_CURRENCY=USD
+# DEFAULT_LOCALE=en-US
+
 # =============================================================================
 # EMAIL CONFIGURATION (Required for password reset, invitations, and email OTP)
 # =============================================================================

--- a/apps/server/config.py
+++ b/apps/server/config.py
@@ -247,6 +247,11 @@ OAUTH_OIDC_SKIP_EMAIL_VERIFICATION = (
 ENABLE_2FA = os.environ.get("ENABLE_2FA", "false").lower() == "true"
 ENABLE_PASSKEYS = os.environ.get("ENABLE_PASSKEYS", "false").lower() == "true"
 
+# Default currency for formatting amounts in the UI (ISO 4217 code)
+DEFAULT_CURRENCY = os.environ.get("DEFAULT_CURRENCY", "USD").upper()
+# Default locale for formatting numbers/dates in the UI (BCP 47 tag)
+DEFAULT_LOCALE = os.environ.get("DEFAULT_LOCALE", "en-US")
+
 # WebAuthn Relying Party configuration
 WEBAUTHN_RP_ID = os.environ.get("WEBAUTHN_RP_ID", "localhost")
 WEBAUTHN_RP_NAME = os.environ.get("WEBAUTHN_RP_NAME", "BillManager")
@@ -272,6 +277,8 @@ def get_public_config():
         ],
         "twofa_enabled": ENABLE_2FA,
         "passkeys_enabled": ENABLE_PASSKEYS,
+        "default_currency": DEFAULT_CURRENCY,
+        "default_locale": DEFAULT_LOCALE,
         "tier_limits": TIER_LIMITS if is_saas() else None,
         "pricing": {
             "basic": {

--- a/apps/web/src/__tests__/currency.test.ts
+++ b/apps/web/src/__tests__/currency.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  formatCurrency,
+  formatCurrencyAxis,
+  getCurrencySymbol,
+  setCurrencyConfig,
+} from '../lib/currency';
+
+afterEach(() => {
+  setCurrencyConfig('en-US', 'USD');
+  vi.restoreAllMocks();
+});
+
+describe('currency formatting', () => {
+  it('uses the configured locale and currency', () => {
+    setCurrencyConfig('de-DE', 'EUR');
+
+    expect(formatCurrency(1234.56)).toBe(
+      new Intl.NumberFormat('de-DE', {
+        style: 'currency',
+        currency: 'EUR',
+      }).format(1234.56)
+    );
+    expect(formatCurrencyAxis(1234.56)).toBe(
+      new Intl.NumberFormat('de-DE', {
+        style: 'currency',
+        currency: 'EUR',
+        maximumFractionDigits: 0,
+      }).format(1234.56)
+    );
+    expect(getCurrencySymbol()).toBe('€');
+  });
+
+  it('formats missing values as zero', () => {
+    expect(formatCurrency(null)).toBe(formatCurrency(0));
+    expect(formatCurrency(undefined)).toBe(formatCurrency(0));
+  });
+
+  it('keeps the previous configuration when the locale is invalid', () => {
+    setCurrencyConfig('de-DE', 'EUR');
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    setCurrencyConfig('invalid_locale', 'NOT-A-CURRENCY');
+
+    expect(formatCurrency(1234.56)).toBe(
+      new Intl.NumberFormat('de-DE', {
+        style: 'currency',
+        currency: 'EUR',
+      }).format(1234.56)
+    );
+  });
+});

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -592,6 +592,8 @@ export interface AppConfig {
   oauth_providers?: { id: string; display_name: string; icon: string }[];
   twofa_enabled?: boolean;
   passkeys_enabled?: boolean;
+  default_currency?: string;
+  default_locale?: string;
 }
 
 export interface AppConfigResponse {

--- a/apps/web/src/components/Analytics/AccountPieChart.tsx
+++ b/apps/web/src/components/Analytics/AccountPieChart.tsx
@@ -3,6 +3,7 @@ import '@mantine/charts/styles.css';
 import { Paper, Title, Text, Stack, Group, Box, ColorSwatch } from '@mantine/core';
 import { PieChart } from '@mantine/charts';
 import type { AccountStats } from '../../api/client';
+import { formatCurrency } from '../../lib/currency';
 
 interface AccountPieChartProps {
   data: AccountStats[];
@@ -101,7 +102,7 @@ export function AccountPieChart({ data, loading }: AccountPieChartProps) {
               </Group>
               <Group gap="xs">
                 <Text size="sm" fw={500}>
-                  ${item.value.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+                  {formatCurrency(item.value)}
                 </Text>
                 <Text size="xs" c="dimmed">
                   ({((item.value / total) * 100).toFixed(1)}%)
@@ -113,7 +114,7 @@ export function AccountPieChart({ data, loading }: AccountPieChartProps) {
       </Group>
 
       <Text size="xs" c="dimmed" mt="md" ta="center">
-        Total: ${total.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+        Total: {formatCurrency(total)}
       </Text>
     </Paper>
   );

--- a/apps/web/src/components/Analytics/YoYComparison.tsx
+++ b/apps/web/src/components/Analytics/YoYComparison.tsx
@@ -3,6 +3,7 @@ import '@mantine/charts/styles.css';
 import { Paper, Title, Text, Box, Group, Stack } from '@mantine/core';
 import { BarChart } from '@mantine/charts';
 import type { MonthlyComparison } from '../../api/client';
+import { formatCurrency } from '../../lib/currency';
 
 interface YoYComparisonProps {
   data: MonthlyComparison | null;
@@ -101,7 +102,7 @@ export function YoYComparison({ data, loading }: YoYComparisonProps) {
                   <Group key={String(item.name)} gap="xs">
                     <Box style={{ width: 8, height: 8, background: item.color, borderRadius: 2 }} />
                     <Text size="sm">
-                      {String(item.name)}: ${Number(item.value ?? 0).toLocaleString('en-US', { minimumFractionDigits: 2 })}
+                      {String(item.name)}: {formatCurrency(Number(item.value ?? 0))}
                     </Text>
                   </Group>
                 ))}
@@ -114,11 +115,11 @@ export function YoYComparison({ data, loading }: YoYComparisonProps) {
       <Group justify="space-around" mt="md">
         <Stack gap={0} align="center">
           <Text size="xs" c="dimmed">{data.last_year} Total</Text>
-          <Text fw={600}>${totals.lastYear.toLocaleString('en-US', { minimumFractionDigits: 2 })}</Text>
+          <Text fw={600}>{formatCurrency(totals.lastYear)}</Text>
         </Stack>
         <Stack gap={0} align="center">
           <Text size="xs" c="dimmed">{data.current_year} Total</Text>
-          <Text fw={600}>${totals.currentYear.toLocaleString('en-US', { minimumFractionDigits: 2 })}</Text>
+          <Text fw={600}>{formatCurrency(totals.currentYear)}</Text>
         </Stack>
       </Group>
     </Paper>

--- a/apps/web/src/components/BillList.tsx
+++ b/apps/web/src/components/BillList.tsx
@@ -23,6 +23,7 @@ import { exportBillsToCSV, exportBillsToPDF, printBills } from '../utils/export'
 import type { Bill } from '../api/client';
 import { getAccounts, getCategories, markSharePaid } from '../api/client';
 import { BillIcon } from './BillIcon';
+import { formatCurrency } from '../lib/currency';
 import type { BillFilter } from '../App';
 
 interface BillListProps {
@@ -490,17 +491,17 @@ export function BillList({
                     <Text c={bill.type === 'deposit' ? 'green' : 'red'}>
                       Varies{' '}
                       <Text span size="xs">
-                        (~${(bill.avg_amount || 0).toFixed(2)})
+                        (~{formatCurrency(bill.avg_amount || 0)})
                       </Text>
                     </Text>
                   ) : (
                     <>
                       <Text fw={500} c={bill.type === 'deposit' ? 'green' : 'red'}>
-                        ${(bill.amount || 0).toFixed(2)}
+                        {formatCurrency(bill.amount || 0)}
                       </Text>
                       {bill.is_shared && bill.share_info?.my_portion !== null && bill.share_info?.my_portion !== undefined && (
                         <Text size="xs" c="dimmed">
-                          My portion: ${bill.share_info.my_portion.toFixed(2)}
+                          My portion: {formatCurrency(bill.share_info.my_portion)}
                         </Text>
                       )}
                     </>
@@ -593,7 +594,7 @@ export function BillList({
               <Paper p="md" withBorder bg="gray.0">
                 <Group justify="space-between">
                   <Text size="sm" c="dimmed">Your portion:</Text>
-                  <Text fw={600} size="lg">${confirmPayBill.share_info.my_portion.toFixed(2)}</Text>
+                  <Text fw={600} size="lg">{formatCurrency(confirmPayBill.share_info.my_portion)}</Text>
                 </Group>
               </Paper>
             )}

--- a/apps/web/src/components/BillModal.tsx
+++ b/apps/web/src/components/BillModal.tsx
@@ -29,6 +29,7 @@ import { IconPicker } from './IconPicker';
 import { BillIcon } from './BillIcon';
 import { ShareBillModal } from './ShareBillModal';
 import { formatDateForAPI, parseLocalDate } from '../utils/date';
+import { getCurrencySymbol } from '../lib/currency';
 
 interface BillFormValues {
   name: string;
@@ -400,7 +401,7 @@ export function BillModal({ opened, onClose, onSave, onArchive, onUnarchive, onD
               <NumberInput
                 label="Amount"
                 placeholder="0.00"
-                prefix="$"
+                prefix={getCurrencySymbol()}
                 decimalScale={2}
                 fixedDecimalScale
                 disabled={form.values.varies}

--- a/apps/web/src/components/Dashboard/CashFlowForecast.tsx
+++ b/apps/web/src/components/Dashboard/CashFlowForecast.tsx
@@ -28,6 +28,7 @@ import {
 import * as api from '../../api/client';
 import type { CashFlowForecast as CashFlowForecastData } from '../../api/client';
 import { BillIcon } from '../BillIcon';
+import { formatCurrency } from '../../lib/currency';
 
 interface CashFlowForecastProps {
   hasDatabase: boolean;
@@ -36,15 +37,6 @@ interface CashFlowForecastProps {
 }
 
 const STORAGE_KEY = 'billmanager:forecast-starting-balance';
-
-const currencyFormatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-});
-
-function formatCurrency(value: number | null | undefined): string {
-  return currencyFormatter.format(value ?? 0);
-}
 
 function formatShortDate(dateStr: string): string {
   const [year, month, day] = dateStr.split('-').map(Number);

--- a/apps/web/src/components/Dashboard/CashFlowForecast.tsx
+++ b/apps/web/src/components/Dashboard/CashFlowForecast.tsx
@@ -28,7 +28,7 @@ import {
 import * as api from '../../api/client';
 import type { CashFlowForecast as CashFlowForecastData } from '../../api/client';
 import { BillIcon } from '../BillIcon';
-import { formatCurrency } from '../../lib/currency';
+import { formatCurrency, formatCurrencyAxis, getCurrencySymbol } from '../../lib/currency';
 
 interface CashFlowForecastProps {
   hasDatabase: boolean;
@@ -144,7 +144,7 @@ export function CashFlowForecast({ hasDatabase, framed = true, showHeader = true
           <Group gap="sm" align="flex-end">
             <NumberInput
               label="Starting balance"
-              prefix="$"
+              prefix={getCurrencySymbol()}
               decimalScale={2}
               value={startingBalance}
               onChange={(value) => setStartingBalance(typeof value === 'number' ? value : 0)}
@@ -220,7 +220,7 @@ export function CashFlowForecast({ hasDatabase, framed = true, showHeader = true
                 curveType="linear"
                 withTooltip
                 yAxisProps={{
-                  tickFormatter: (value: number) => `$${value}`,
+                  tickFormatter: (value: number) => formatCurrencyAxis(value),
                 }}
               />
             )}

--- a/apps/web/src/components/Dashboard/OverdueAlerts.tsx
+++ b/apps/web/src/components/Dashboard/OverdueAlerts.tsx
@@ -1,6 +1,7 @@
 import { Paper, Text, Group, Button, Stack, Box, Alert } from '@mantine/core';
 import { IconAlertTriangle, IconCoin } from '@tabler/icons-react';
 import type { Bill } from '../../api/client';
+import { formatCurrency } from '../../lib/currency';
 
 interface OverdueAlertsProps {
   bills: Bill[];
@@ -60,7 +61,7 @@ export function OverdueAlerts({ bills, onPay }: OverdueAlertsProps) {
                     {bill.name}
                   </Text>
                   <Text size="xs" c="red">
-                    {daysOverdue} day{daysOverdue > 1 ? 's' : ''} overdue - ${amount.toFixed(2)}
+                    {daysOverdue} day{daysOverdue > 1 ? 's' : ''} overdue - {formatCurrency(amount)}
                   </Text>
                 </Box>
                 <Button

--- a/apps/web/src/components/Dashboard/StatCards.tsx
+++ b/apps/web/src/components/Dashboard/StatCards.tsx
@@ -1,6 +1,7 @@
 import { Paper, Text, Group, SimpleGrid, ThemeIcon, Stack } from '@mantine/core';
 import { IconReceipt, IconCalendar, IconAlertTriangle, IconCoin } from '@tabler/icons-react';
 import type { Bill } from '../../api/client';
+import { formatCurrency } from '../../lib/currency';
 
 interface StatCardsProps {
   bills: Bill[];
@@ -110,12 +111,12 @@ export function StatCards({ bills, monthlyPaid, onStatClick }: StatCardsProps) {
               Monthly Total
             </Text>
             <Text fw={700} size="xl" c="green">
-              ${monthlyTotal.toFixed(2)}
+              {formatCurrency(monthlyTotal)}
             </Text>
             <Group gap="xs">
-              <Text size="xs" c="green.6" fw={500}>${monthlyPaid.toFixed(2)} paid</Text>
+              <Text size="xs" c="green.6" fw={500}>{formatCurrency(monthlyPaid)} paid</Text>
               <Text size="xs" c="dimmed">|</Text>
-              <Text size="xs" c="orange.6" fw={500}>${monthlyRemaining.toFixed(2)} remaining</Text>
+              <Text size="xs" c="orange.6" fw={500}>{formatCurrency(monthlyRemaining)} remaining</Text>
             </Group>
           </Stack>
           <ThemeIcon color="green" variant="light" size="lg" radius="md">

--- a/apps/web/src/components/Dashboard/UpcomingBillsList.tsx
+++ b/apps/web/src/components/Dashboard/UpcomingBillsList.tsx
@@ -2,6 +2,7 @@ import { Paper, Title, Text, Group, Button, Table, Badge, ThemeIcon, ActionIcon,
 import { IconCalendar, IconCash, IconEdit, IconUsers } from '@tabler/icons-react';
 import type { Bill } from '../../api/client';
 import { BillIcon } from '../BillIcon';
+import { formatCurrency } from '../../lib/currency';
 
 interface UpcomingBillsListProps {
   bills: Bill[];
@@ -186,12 +187,12 @@ export function UpcomingBillsList({ bills, onPay, onEdit, onViewPayments, onView
                     <Text c={bill.type === 'deposit' ? 'green' : 'red'}>
                       Varies{' '}
                       <Text span size="xs">
-                        (~${(bill.avg_amount || 0).toFixed(2)})
+                        (~{formatCurrency(bill.avg_amount || 0)})
                       </Text>
                     </Text>
                   ) : (
                     <Text fw={500} c={bill.type === 'deposit' ? 'green' : 'red'}>
-                      ${(bill.amount || 0).toFixed(2)}
+                      {formatCurrency(bill.amount || 0)}
                     </Text>
                   )}
                 </Table.Td>

--- a/apps/web/src/components/DayDetailModal.tsx
+++ b/apps/web/src/components/DayDetailModal.tsx
@@ -1,6 +1,7 @@
 import { Modal, Stack, Text, Paper, Group, Button, Badge, Box } from '@mantine/core';
 import { IconCoin, IconCoinOff } from '@tabler/icons-react';
 import type { Bill } from '../api/client';
+import { formatCurrency } from '../lib/currency';
 
 interface DayDetailModalProps {
   opened: boolean;
@@ -49,13 +50,13 @@ export function DayDetailModal({ opened, onClose, date, bills, onPay, onEdit }: 
               {expenses.length > 0 && (
                 <Paper withBorder p="xs" radius="sm" bg="red.0">
                   <Text size="xs" c="red.7" fw={500}>Expenses</Text>
-                  <Text fw={700} c="red.8">${expenseTotal.toFixed(2)}</Text>
+                  <Text fw={700} c="red.8">{formatCurrency(expenseTotal)}</Text>
                 </Paper>
               )}
               {deposits.length > 0 && (
                 <Paper withBorder p="xs" radius="sm" bg="green.0">
                   <Text size="xs" c="green.7" fw={500}>Deposits</Text>
-                  <Text fw={700} c="green.8">${depositTotal.toFixed(2)}</Text>
+                  <Text fw={700} c="green.8">{formatCurrency(depositTotal)}</Text>
                 </Paper>
               )}
             </Group>
@@ -88,7 +89,7 @@ export function DayDetailModal({ opened, onClose, date, bills, onPay, onEdit }: 
                           )}
                         </Group>
                         <Text size="sm" c="dimmed">
-                          ${amount.toFixed(2)}
+                          {formatCurrency(amount)}
                           {bill.account && ` - ${bill.account}`}
                         </Text>
                       </Box>

--- a/apps/web/src/components/MonthlyTotalsChart.tsx
+++ b/apps/web/src/components/MonthlyTotalsChart.tsx
@@ -4,6 +4,7 @@ import { Modal, Stack, Text, Loader, Center, Paper, Group, SegmentedControl, Sim
 import { LineChart, BarChart } from '@mantine/charts';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { getMonthlyPayments, ApiError } from '../api/client';
+import { formatCurrency, formatCurrencyAxis } from '../lib/currency';
 
 interface MonthlyTotalsChartProps {
   opened: boolean;
@@ -121,20 +122,20 @@ export function MonthlyTotalsChart({ opened, onClose }: MonthlyTotalsChartProps)
             <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="sm">
               <Paper p="sm" withBorder>
                 <Text size="xs" c="dimmed">Total Spent</Text>
-                <Text size="lg" fw={700} c="violet">${totalSpent.toFixed(2)}</Text>
+                <Text size="lg" fw={700} c="violet">{formatCurrency(totalSpent)}</Text>
               </Paper>
               <Paper p="sm" withBorder>
                 <Text size="xs" c="dimmed">Monthly Avg</Text>
-                <Text size="lg" fw={700} c="blue">${avgMonthly.toFixed(2)}</Text>
+                <Text size="lg" fw={700} c="blue">{formatCurrency(avgMonthly)}</Text>
               </Paper>
               <Paper p="sm" withBorder>
                 <Text size="xs" c="dimmed">Highest</Text>
-                <Text size="lg" fw={700} c="red">${maxMonth.total.toFixed(2)}</Text>
+                <Text size="lg" fw={700} c="red">{formatCurrency(maxMonth.total)}</Text>
                 <Text size="xs" c="dimmed">{maxMonth.label}</Text>
               </Paper>
               <Paper p="sm" withBorder>
                 <Text size="xs" c="dimmed">Lowest</Text>
-                <Text size="lg" fw={700} c="green">${minMonth.total === Infinity ? 0 : minMonth.total.toFixed(2)}</Text>
+                <Text size="lg" fw={700} c="green">{formatCurrency(minMonth.total === Infinity ? 0 : minMonth.total)}</Text>
                 <Text size="xs" c="dimmed">{minMonth.total === Infinity ? 'N/A' : minMonth.label}</Text>
               </Paper>
             </SimpleGrid>
@@ -156,14 +157,14 @@ export function MonthlyTotalsChart({ opened, onClose }: MonthlyTotalsChartProps)
                         <Paper px="md" py="sm" withBorder shadow="md" radius="md">
                           <Text fw={500}>{item.label}</Text>
                           <Text c="dimmed" size="sm">
-                            ${item.total.toFixed(2)}
+                            {formatCurrency(item.total)}
                           </Text>
                         </Paper>
                       );
                     },
                   }}
                   yAxisProps={{
-                    tickFormatter: (value: number) => `$${value}`,
+                    tickFormatter: (value: number) => formatCurrencyAxis(value),
                   }}
                 />
               ) : (
@@ -183,14 +184,14 @@ export function MonthlyTotalsChart({ opened, onClose }: MonthlyTotalsChartProps)
                         <Paper px="md" py="sm" withBorder shadow="md" radius="md">
                           <Text fw={500}>{item.label}</Text>
                           <Text c="dimmed" size="sm">
-                            ${item.total.toFixed(2)}
+                            {formatCurrency(item.total)}
                           </Text>
                         </Paper>
                       );
                     },
                   }}
                   yAxisProps={{
-                    tickFormatter: (value: number) => `$${value}`,
+                    tickFormatter: (value: number) => formatCurrencyAxis(value),
                   }}
                 />
               )}

--- a/apps/web/src/components/PayModal.tsx
+++ b/apps/web/src/components/PayModal.tsx
@@ -9,6 +9,7 @@ import {
   Text,
 } from '@mantine/core';
 import type { Bill } from '../api/client';
+import { getCurrencySymbol } from '../lib/currency';
 
 interface PayModalProps {
   opened: boolean;
@@ -61,7 +62,7 @@ export function PayModal({ opened, onClose, onPay, bill }: PayModalProps) {
         <NumberInput
           label={isDeposit ? 'Deposit Amount' : 'Payment Amount'}
           placeholder="0.00"
-          prefix="$"
+          prefix={getCurrencySymbol()}
           decimalScale={2}
           fixedDecimalScale
           min={0}

--- a/apps/web/src/components/PaymentHistory.tsx
+++ b/apps/web/src/components/PaymentHistory.tsx
@@ -21,6 +21,7 @@ import type { Payment, Bill } from '../api/client';
 import { getPayments, updatePayment, deletePayment, ApiError } from '../api/client';
 import { PaymentHistoryChart } from './PaymentHistoryChart';
 import { parseLocalDate, formatDateString, formatDateForAPI } from '../utils/date';
+import { formatCurrency, getCurrencySymbol } from '../lib/currency';
 
 interface PaymentHistoryProps {
   opened: boolean;
@@ -169,7 +170,7 @@ export function PaymentHistory({
               <Group justify="space-between">
                 <Text size="sm" fw={500}>
                   Your Portion:{' '}
-                  {shareInfo.my_portion !== null ? `$${shareInfo.my_portion.toFixed(2)}` : 'N/A'}
+                  {shareInfo.my_portion !== null ? formatCurrency(shareInfo.my_portion) : 'N/A'}
                 </Text>
                 {shareInfo.my_portion_paid ? (
                   <Badge size="sm" color="green" variant="filled">
@@ -235,14 +236,14 @@ export function PaymentHistory({
                       <NumberInput
                         value={editAmount}
                         onChange={(val) => setEditAmount(val === '' ? '' : Number(val))}
-                        prefix="$"
+                        prefix={getCurrencySymbol()}
                         decimalScale={2}
                         fixedDecimalScale
                         size="xs"
                         w={100}
                       />
                     ) : (
-                      <Text fw={500}>${payment.amount.toFixed(2)}</Text>
+                      <Text fw={500}>{formatCurrency(payment.amount)}</Text>
                     )}
                   </Table.Td>
                   <Table.Td>

--- a/apps/web/src/components/PaymentHistoryChart.tsx
+++ b/apps/web/src/components/PaymentHistoryChart.tsx
@@ -4,6 +4,7 @@ import { Paper, Text, Loader, Center } from '@mantine/core';
 import { AreaChart } from '@mantine/charts';
 import { getBillMonthlyPayments } from '../api/client';
 import type { MonthlyBillPayment } from '../api/client';
+import { formatCurrency, formatCurrencyAxis } from '../lib/currency';
 
 interface PaymentHistoryChartProps {
   billName: string | null;
@@ -101,14 +102,14 @@ export function PaymentHistoryChart({ billName }: PaymentHistoryChartProps) {
               <Paper px="md" py="sm" withBorder shadow="md" radius="md">
                 <Text fw={500}>{item.label}</Text>
                 <Text c="dimmed" size="sm">
-                  ${item.total.toFixed(2)}
+                  {formatCurrency(item.total)}
                 </Text>
               </Paper>
             );
           },
         }}
         yAxisProps={{
-          tickFormatter: (value: number) => `$${value}`,
+          tickFormatter: (value: number) => formatCurrencyAxis(value),
         }}
       />
     </Paper>

--- a/apps/web/src/components/ReminderAlertsWidget.tsx
+++ b/apps/web/src/components/ReminderAlertsWidget.tsx
@@ -4,6 +4,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { IconAlertTriangle, IconBellRinging } from '@tabler/icons-react';
 import type { Bill, ReminderAlert } from '../api/client';
 import { getReminderAlerts } from '../api/client';
+import { formatCurrency } from '../lib/currency';
 
 interface ReminderAlertsWidgetProps {
   bills: Bill[];
@@ -95,7 +96,7 @@ export function ReminderAlertsWidget({ bills, hasDatabase, onPayBill }: Reminder
                     </Group>
                     <Text size="sm" c="dimmed">
                       {alert.message}
-                      {alert.amount !== null ? ` - $${alert.amount.toFixed(2)}` : ''}
+                      {alert.amount !== null ? ` - ${formatCurrency(alert.amount)}` : ''}
                     </Text>
                   </Stack>
                   {bill && bill.type !== 'deposit' && !bill.is_shared && (

--- a/apps/web/src/components/ShareBillModal.tsx
+++ b/apps/web/src/components/ShareBillModal.tsx
@@ -19,6 +19,7 @@ import { IconShare, IconTrash, IconAlertCircle, IconCheck, IconEdit } from '@tab
 import * as api from '../api/client';
 import type { Bill, BillShare, UserSearchResult } from '../api/client';
 import { useConfig } from '../context/ConfigContext';
+import { formatCurrency, getCurrencySymbol } from '../lib/currency';
 
 interface ShareBillModalProps {
   opened: boolean;
@@ -285,13 +286,13 @@ export function ShareBillModal({ opened, onClose, bill }: ShareBillModalProps) {
                 onChange={(val) => setSplitValue(typeof val === 'number' ? val : undefined)}
                 min={0}
                 decimalScale={2}
-                prefix="$"
+                prefix={getCurrencySymbol()}
               />
             )}
 
             {portion !== null && bill?.amount && (
               <Text size="sm" c="dimmed">
-                Their portion: ${portion.toFixed(2)} of ${bill.amount.toFixed(2)}
+                Their portion: {formatCurrency(portion)} of {formatCurrency(bill.amount)}
               </Text>
             )}
 
@@ -362,7 +363,7 @@ export function ShareBillModal({ opened, onClose, bill }: ShareBillModalProps) {
                           onChange={(val) => setEditSplitValue(typeof val === 'number' ? val : undefined)}
                           min={0}
                           decimalScale={2}
-                          prefix="$"
+                          prefix={getCurrencySymbol()}
                           size="xs"
                         />
                       )}
@@ -390,7 +391,7 @@ export function ShareBillModal({ opened, onClose, bill }: ShareBillModalProps) {
                               ? '50/50'
                               : share.split_type === 'percentage'
                                 ? `${share.split_value}%`
-                                : `$${share.split_value?.toFixed(2)}`}
+                                : formatCurrency(share.split_value)}
                           </Badge>
                         )}
                       </Group>

--- a/apps/web/src/components/SharedBillsSection.tsx
+++ b/apps/web/src/components/SharedBillsSection.tsx
@@ -26,6 +26,7 @@ import {
 import * as api from '../api/client';
 import type { SharedBill, PendingShare } from '../api/client';
 import { BillIcon } from './BillIcon';
+import { formatCurrency } from '../lib/currency';
 
 interface SharedBillsSectionProps {
   onRefresh?: () => void;
@@ -188,7 +189,7 @@ export function SharedBillsSection({ onRefresh }: SharedBillsSectionProps) {
                                 |
                               </Text>
                               <Text size="xs" c="dimmed">
-                                Your portion: ${share.my_portion.toFixed(2)}
+                                Your portion: {formatCurrency(share.my_portion)}
                               </Text>
                             </>
                           )}
@@ -269,15 +270,15 @@ export function SharedBillsSection({ onRefresh }: SharedBillsSectionProps) {
                           {shared.my_portion && shared.my_portion !== shared.bill.amount ? (
                             <>
                               <Text size="sm" fw={600} c={shared.bill.type === 'deposit' ? 'green' : 'red'}>
-                                ${shared.my_portion.toFixed(2)}
+                                {formatCurrency(shared.my_portion)}
                               </Text>
                               <Text size="xs" c="dimmed">
-                                of ${(shared.bill.amount || 0).toFixed(2)}
+                                of {formatCurrency(shared.bill.amount || 0)}
                               </Text>
                             </>
                           ) : (
                             <Text size="sm" fw={600} c={shared.bill.type === 'deposit' ? 'green' : 'red'}>
-                              ${(shared.bill.amount || 0).toFixed(2)}
+                              {formatCurrency(shared.bill.amount || 0)}
                             </Text>
                           )}
                         </Stack>

--- a/apps/web/src/context/ConfigContext.tsx
+++ b/apps/web/src/context/ConfigContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
 import * as api from '../api/client';
+import { setCurrencyConfig } from '../lib/currency';
 
 export interface OAuthProviderInfo {
   id: string;
@@ -16,6 +17,8 @@ export interface AppConfig {
   oauth_providers?: OAuthProviderInfo[];
   twofa_enabled?: boolean;
   passkeys_enabled?: boolean;
+  default_currency?: string;
+  default_locale?: string;
 }
 
 interface ConfigContextType {
@@ -27,6 +30,8 @@ interface ConfigContextType {
   emailEnabled: boolean;
   billingEnabled: boolean;
   registrationEnabled: boolean;
+  currency: string;
+  locale: string;
   refetch: () => Promise<void>;
 }
 
@@ -39,6 +44,8 @@ const defaultConfig: AppConfig = {
   oauth_providers: [],
   twofa_enabled: false,
   passkeys_enabled: false,
+  default_currency: 'USD',
+  default_locale: 'en-US',
 };
 
 const ConfigContext = createContext<ConfigContextType>({
@@ -50,6 +57,8 @@ const ConfigContext = createContext<ConfigContextType>({
   emailEnabled: false,
   billingEnabled: false,
   registrationEnabled: false,
+  currency: 'USD',
+  locale: 'en-US',
   refetch: async () => {},
 });
 
@@ -62,6 +71,10 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     try {
       const response = await api.getAppConfig();
       setConfig(response);
+      setCurrencyConfig(
+        response.default_locale ?? 'en-US',
+        response.default_currency ?? 'USD'
+      );
       setError(null);
     } catch (err) {
       console.error('Failed to fetch app config:', err);
@@ -86,6 +99,8 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     emailEnabled: config?.email_enabled ?? false,
     billingEnabled: config?.billing_enabled ?? false,
     registrationEnabled: config?.registration_enabled ?? false,
+    currency: config?.default_currency ?? 'USD',
+    locale: config?.default_locale ?? 'en-US',
     refetch: fetchConfig,
   };
 

--- a/apps/web/src/lib/currency.ts
+++ b/apps/web/src/lib/currency.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared currency formatting utility.
+ *
+ * Currency and locale are configurable via the DEFAULT_CURRENCY /
+ * DEFAULT_LOCALE environment variables (see apps/server/config.py),
+ * exposed to the frontend through the /api/v2/config endpoint.
+ *
+ * ConfigProvider calls setCurrencyConfig() once the config is fetched.
+ * This module-level state (rather than threading props through every
+ * caller) exists because many formatCurrency() call sites are plain
+ * helper functions outside the React component tree and can't use
+ * useConfig() directly.
+ */
+
+let currentLocale = 'en-US';
+let currentCurrency = 'USD';
+let formatter = buildFormatter();
+let axisFormatter = buildFormatter({ maximumFractionDigits: 0 });
+
+function buildFormatter(extra: Intl.NumberFormatOptions = {}): Intl.NumberFormat {
+  return new Intl.NumberFormat(currentLocale, {
+    style: 'currency',
+    currency: currentCurrency,
+    ...extra,
+  });
+}
+
+export function setCurrencyConfig(locale: string, currency: string): void {
+  if (locale === currentLocale && currency === currentCurrency) {
+    return;
+  }
+  const previousLocale = currentLocale;
+  const previousCurrency = currentCurrency;
+  currentLocale = locale;
+  currentCurrency = currency;
+  try {
+    formatter = buildFormatter();
+    axisFormatter = buildFormatter({ maximumFractionDigits: 0 });
+  } catch {
+    // Invalid locale/currency combination (e.g. bad env var) - roll back
+    // rather than breaking the whole UI.
+    console.warn(
+      `Invalid locale/currency "${locale}"/"${currency}", keeping "${previousLocale}"/"${previousCurrency}"`
+    );
+    currentLocale = previousLocale;
+    currentCurrency = previousCurrency;
+  }
+}
+
+export function formatCurrency(value: number | null | undefined): string {
+  return formatter.format(value ?? 0);
+}
+
+/**
+ * Compact currency formatting without decimals, for chart axis ticks
+ * where full cent precision isn't useful.
+ */
+export function formatCurrencyAxis(value: number | null | undefined): string {
+  return axisFormatter.format(value ?? 0);
+}

--- a/apps/web/src/lib/currency.ts
+++ b/apps/web/src/lib/currency.ts
@@ -16,6 +16,7 @@ let currentLocale = 'en-US';
 let currentCurrency = 'USD';
 let formatter = buildFormatter();
 let axisFormatter = buildFormatter({ maximumFractionDigits: 0 });
+let cachedSymbol = extractSymbol(formatter);
 
 function buildFormatter(extra: Intl.NumberFormatOptions = {}): Intl.NumberFormat {
   return new Intl.NumberFormat(currentLocale, {
@@ -23,6 +24,11 @@ function buildFormatter(extra: Intl.NumberFormatOptions = {}): Intl.NumberFormat
     currency: currentCurrency,
     ...extra,
   });
+}
+
+function extractSymbol(fmt: Intl.NumberFormat): string {
+  const part = fmt.formatToParts(0).find((p) => p.type === 'currency');
+  return part?.value ?? currentCurrency;
 }
 
 export function setCurrencyConfig(locale: string, currency: string): void {
@@ -36,6 +42,7 @@ export function setCurrencyConfig(locale: string, currency: string): void {
   try {
     formatter = buildFormatter();
     axisFormatter = buildFormatter({ maximumFractionDigits: 0 });
+    cachedSymbol = extractSymbol(formatter);
   } catch {
     // Invalid locale/currency combination (e.g. bad env var) - roll back
     // rather than breaking the whole UI.
@@ -57,4 +64,12 @@ export function formatCurrency(value: number | null | undefined): string {
  */
 export function formatCurrencyAxis(value: number | null | undefined): string {
   return axisFormatter.format(value ?? 0);
+}
+
+/**
+ * Currency symbol only (e.g. "$", "€"), for use as a NumberInput prefix
+ * where full Intl formatting doesn't apply (raw numeric entry fields).
+ */
+export function getCurrencySymbol(): string {
+  return cachedSymbol;
 }

--- a/apps/web/src/pages/AcceptShareInvite.tsx
+++ b/apps/web/src/pages/AcceptShareInvite.tsx
@@ -17,6 +17,7 @@ import {
 import { IconAlertCircle, IconCheck, IconCurrencyDollar } from '@tabler/icons-react';
 import { getShareInviteDetails, acceptShareByToken } from '../api/client';
 import { useAuth } from '../context/AuthContext';
+import { formatCurrency } from '../lib/currency';
 
 export function AcceptShareInvite() {
   const navigate = useNavigate();
@@ -161,7 +162,7 @@ export function AcceptShareInvite() {
               <Text size="sm" c="dimmed" mb={5}>Full Amount</Text>
               <Group gap="xs">
                 <IconCurrencyDollar size={20} />
-                <Text size="lg" fw={500}>${inviteData?.bill_amount.toFixed(2)}</Text>
+                <Text size="lg" fw={500}>{formatCurrency(inviteData?.bill_amount)}</Text>
               </Group>
             </div>
 
@@ -170,7 +171,7 @@ export function AcceptShareInvite() {
                 <Text size="sm" c="dimmed" mb={5}>Your Portion</Text>
                 <Group gap="xs">
                   <Badge color="blue" size="lg">
-                    ${inviteData.my_portion.toFixed(2)}
+                    {formatCurrency(inviteData.my_portion)}
                   </Badge>
                   {inviteData.split_type === 'percentage' && (
                     <Text size="sm" c="dimmed">({inviteData.split_value}%)</Text>
@@ -235,7 +236,7 @@ export function AcceptShareInvite() {
             <Text size="sm" c="dimmed" mb={5}>Full Amount</Text>
             <Group gap="xs">
               <IconCurrencyDollar size={20} />
-              <Text size="lg" fw={500}>${inviteData?.bill_amount.toFixed(2)}</Text>
+              <Text size="lg" fw={500}>{formatCurrency(inviteData?.bill_amount)}</Text>
             </Group>
           </div>
 
@@ -244,7 +245,7 @@ export function AcceptShareInvite() {
               <Text size="sm" c="dimmed" mb={5}>Your Portion</Text>
               <Group gap="xs">
                 <Badge color="blue" size="lg">
-                  ${inviteData.my_portion.toFixed(2)}
+                  {formatCurrency(inviteData.my_portion)}
                 </Badge>
                 {inviteData.split_type === 'percentage' && (
                   <Text size="sm" c="dimmed">({inviteData.split_value}%)</Text>

--- a/apps/web/src/pages/AllPayments.tsx
+++ b/apps/web/src/pages/AllPayments.tsx
@@ -31,6 +31,7 @@ import { BillIcon } from '../components/BillIcon';
 import { IconEdit, IconTrash, IconCheck } from '@tabler/icons-react';
 import { exportPaymentsToCSV, exportPaymentsToPDF, printPayments } from '../utils/export';
 import { parseLocalDate, formatDateString, formatDateForAPI } from '../utils/date';
+import { formatCurrency, formatCurrencyAxis, getCurrencySymbol } from '../lib/currency';
 
 interface MonthlyChartData {
   month: string;
@@ -256,7 +257,7 @@ export function AllPayments() {
         </Group>
         <Group gap="sm">
           <Badge size="lg" variant="light">
-            {filteredPayments.length} payments · ${totalAmount.toFixed(2)} total
+            {filteredPayments.length} payments · {formatCurrency(totalAmount)} total
           </Badge>
           <Menu shadow="md" width={200}>
             <Menu.Target>
@@ -339,7 +340,7 @@ export function AllPayments() {
             />
             <NumberInput
               placeholder="Min amount"
-              prefix="$"
+              prefix={getCurrencySymbol()}
               value={amountMin}
               onChange={(val) => setAmountMin(val === '' ? '' : Number(val))}
               decimalScale={2}
@@ -347,7 +348,7 @@ export function AllPayments() {
             />
             <NumberInput
               placeholder="Max amount"
-              prefix="$"
+              prefix={getCurrencySymbol()}
               value={amountMax}
               onChange={(val) => setAmountMax(val === '' ? '' : Number(val))}
               decimalScale={2}
@@ -369,8 +370,8 @@ export function AllPayments() {
                   searchName && `"${searchName}"`,
                   dateFrom && `from ${formatDateString(formatDateForAPI(dateFrom))}`,
                   dateTo && `to ${formatDateString(formatDateForAPI(dateTo))}`,
-                  amountMin !== '' && `min $${amountMin}`,
-                  amountMax !== '' && `max $${amountMax}`,
+                  amountMin !== '' && `min ${getCurrencySymbol()}${amountMin}`,
+                  amountMax !== '' && `max ${getCurrencySymbol()}${amountMax}`,
                 ].filter(Boolean).join(', ')}
               </Text>
               <Badge size="sm" variant="light" color="blue">
@@ -424,14 +425,14 @@ export function AllPayments() {
                     <Paper px="md" py="sm" withBorder shadow="md" radius="md">
                       <Text fw={500}>{item.label}</Text>
                       <Text c="dimmed" size="sm">
-                        ${item.total.toFixed(2)}
+                        {formatCurrency(item.total)}
                       </Text>
                     </Paper>
                   );
                 },
               }}
               yAxisProps={{
-                tickFormatter: (value: number) => `$${value}`,
+                tickFormatter: (value: number) => formatCurrencyAxis(value),
               }}
             />
           </Collapse>
@@ -507,7 +508,7 @@ export function AllPayments() {
                         <NumberInput
                           value={editAmount}
                           onChange={(val) => setEditAmount(val === '' ? '' : Number(val))}
-                          prefix="$"
+                          prefix={getCurrencySymbol()}
                           decimalScale={2}
                           fixedDecimalScale
                           size="xs"
@@ -515,7 +516,7 @@ export function AllPayments() {
                         />
                       ) : (
                         <Text fw={500} c={isDeposit ? 'green' : undefined}>
-                          {isDeposit ? '+' : ''}${payment.amount.toFixed(2)}
+                          {isDeposit ? '+' : ''}{formatCurrency(payment.amount)}
                         </Text>
                       )}
                     </Table.Td>

--- a/apps/web/src/pages/AllPayments.tsx
+++ b/apps/web/src/pages/AllPayments.tsx
@@ -370,8 +370,8 @@ export function AllPayments() {
                   searchName && `"${searchName}"`,
                   dateFrom && `from ${formatDateString(formatDateForAPI(dateFrom))}`,
                   dateTo && `to ${formatDateString(formatDateForAPI(dateTo))}`,
-                  amountMin !== '' && `min ${getCurrencySymbol()}${amountMin}`,
-                  amountMax !== '' && `max ${getCurrencySymbol()}${amountMax}`,
+                  amountMin !== '' && `min ${formatCurrency(Number(amountMin))}`,
+                  amountMax !== '' && `max ${formatCurrency(Number(amountMax))}`,
                 ].filter(Boolean).join(', ')}
               </Text>
               <Badge size="sm" variant="light" color="blue">

--- a/apps/web/src/pages/Analytics.tsx
+++ b/apps/web/src/pages/Analytics.tsx
@@ -35,6 +35,7 @@ import { CashFlowForecast } from '../components/Dashboard/CashFlowForecast';
 import { useAuth } from '../context/AuthContext';
 import { getAllPayments, getMonthlyComparison, getStatsByAccount, getStatsYearly } from '../api/client';
 import type { AccountStats, MonthlyComparison as MonthlyComparisonType, PaymentWithBill, YearlyStats } from '../api/client';
+import { formatCurrency, formatCurrencyAxis } from '../lib/currency';
 
 interface AnalyticsProps {
   hasDatabase: boolean;
@@ -96,10 +97,6 @@ function normalizeLayout(value: Partial<AnalyticsLayout> | null | undefined): An
     : [];
 
   return { order, collapsed };
-}
-
-function formatCurrency(value: number): string {
-  return value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
 function monthKey(date: Date): string {
@@ -398,7 +395,7 @@ export function Analytics({ hasDatabase, currentDb }: AnalyticsProps) {
       <Paper px="md" py="sm" withBorder shadow="md" radius="md">
         <Text fw={600}>{item.label}</Text>
         <Text size="sm" c="dimmed" mb="xs">
-          ${formatCurrency(item.total)}
+          {formatCurrency(item.total)}
         </Text>
         <Stack gap={3}>
           {trend.series
@@ -407,7 +404,7 @@ export function Analytics({ hasDatabase, currentDb }: AnalyticsProps) {
             .map((series) => (
               <Group key={series.name} gap="xs" justify="space-between" wrap="nowrap">
                 <Text size="xs">{series.label}</Text>
-                <Text size="xs" fw={600}>${formatCurrency(series.value)}</Text>
+                <Text size="xs" fw={600}>{formatCurrency(series.value)}</Text>
               </Group>
             ))}
         </Stack>
@@ -429,7 +426,7 @@ export function Analytics({ hasDatabase, currentDb }: AnalyticsProps) {
                     {currentYearData[0]} Expenses
                   </Text>
                   <Text fw={700} size="xl">
-                    ${formatCurrency(currentYearData[1].expenses)}
+                    {formatCurrency(currentYearData[1].expenses)}
                   </Text>
                 </div>
                 <ThemeIcon color="blue" variant="light" size="lg" radius="md">
@@ -447,7 +444,7 @@ export function Analytics({ hasDatabase, currentDb }: AnalyticsProps) {
                     {lastYearData[0]} Expenses
                   </Text>
                   <Text fw={700} size="xl">
-                    ${formatCurrency(lastYearData[1].expenses)}
+                    {formatCurrency(lastYearData[1].expenses)}
                   </Text>
                 </div>
                 <ThemeIcon color="gray" variant="light" size="lg" radius="md">
@@ -509,20 +506,20 @@ export function Analytics({ hasDatabase, currentDb }: AnalyticsProps) {
           <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="sm">
             <Paper p="sm" withBorder>
               <Text size="xs" c="dimmed">Total Spent</Text>
-              <Text size="lg" fw={700} c="violet">${formatCurrency(totalSpent)}</Text>
+              <Text size="lg" fw={700} c="violet">{formatCurrency(totalSpent)}</Text>
             </Paper>
             <Paper p="sm" withBorder>
               <Text size="xs" c="dimmed">Monthly Avg</Text>
-              <Text size="lg" fw={700} c="blue">${formatCurrency(avgMonthly)}</Text>
+              <Text size="lg" fw={700} c="blue">{formatCurrency(avgMonthly)}</Text>
             </Paper>
             <Paper p="sm" withBorder>
               <Text size="xs" c="dimmed">Highest</Text>
-              <Text size="lg" fw={700} c="red">${formatCurrency(maxMonth.total)}</Text>
+              <Text size="lg" fw={700} c="red">{formatCurrency(maxMonth.total)}</Text>
               <Text size="xs" c="dimmed">{maxMonth.label}</Text>
             </Paper>
             <Paper p="sm" withBorder>
               <Text size="xs" c="dimmed">Lowest</Text>
-              <Text size="lg" fw={700} c="green">${formatCurrency(minMonth.total === Infinity ? 0 : minMonth.total)}</Text>
+              <Text size="lg" fw={700} c="green">{formatCurrency(minMonth.total === Infinity ? 0 : minMonth.total)}</Text>
               <Text size="xs" c="dimmed">{minMonth.total === Infinity ? 'N/A' : minMonth.label}</Text>
             </Paper>
           </SimpleGrid>
@@ -538,7 +535,7 @@ export function Analytics({ hasDatabase, currentDb }: AnalyticsProps) {
               withTooltip
               tooltipProps={{ content: chartTooltip }}
               yAxisProps={{
-                tickFormatter: (value: number) => `$${value}`,
+                tickFormatter: (value: number) => formatCurrencyAxis(value),
               }}
             />
           ) : (
@@ -555,7 +552,7 @@ export function Analytics({ hasDatabase, currentDb }: AnalyticsProps) {
               withTooltip
               tooltipProps={{ content: chartTooltip }}
               yAxisProps={{
-                tickFormatter: (value: number) => `$${value}`,
+                tickFormatter: (value: number) => formatCurrencyAxis(value),
               }}
             />
           )}
@@ -601,19 +598,19 @@ export function Analytics({ hasDatabase, currentDb }: AnalyticsProps) {
                 <Divider mb={4} />
                 <Group justify="space-between" gap={4}>
                   <Text size="xs" c="dimmed">Expenses</Text>
-                  <Text size="sm" fw={600} c="red">-${formatCurrency(data.expenses)}</Text>
+                  <Text size="sm" fw={600} c="red">-{formatCurrency(data.expenses)}</Text>
                 </Group>
                 {data.deposits > 0 && (
                   <Group justify="space-between" gap={4}>
                     <Text size="xs" c="dimmed">Deposits</Text>
-                    <Text size="sm" fw={600} c="green">+${formatCurrency(data.deposits)}</Text>
+                    <Text size="sm" fw={600} c="green">+{formatCurrency(data.deposits)}</Text>
                   </Group>
                 )}
                 <Divider my={4} />
                 <Group justify="space-between" gap={4}>
                   <Text size="xs" fw={600}>Net</Text>
                   <Text size="sm" fw={700} c={net >= 0 ? 'green' : 'red'}>
-                    {net >= 0 ? '+' : '-'}${formatCurrency(Math.abs(net))}
+                    {net >= 0 ? '+' : '-'}{formatCurrency(Math.abs(net))}
                   </Text>
                 </Group>
               </Paper>

--- a/apps/web/src/pages/Settlements.tsx
+++ b/apps/web/src/pages/Settlements.tsx
@@ -30,18 +30,10 @@ import {
 import * as api from '../api/client';
 import type { SettlementItem, SettlementsResponse } from '../api/client';
 import { BillIcon } from '../components/BillIcon';
+import { formatCurrency } from '../lib/currency';
 
 interface SettlementsProps {
   hasDatabase: boolean;
-}
-
-const currencyFormatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-});
-
-function formatCurrency(value: number | null | undefined): string {
-  return currencyFormatter.format(value ?? 0);
 }
 
 function formatDate(dateStr: string | null | undefined): string {

--- a/apps/web/src/utils/export.ts
+++ b/apps/web/src/utils/export.ts
@@ -2,6 +2,7 @@ import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import type { Bill, PaymentWithBill } from '../api/client';
 import { formatDateForAPI } from './date';
+import { formatCurrency } from '../lib/currency';
 
 // Format date for display
 function formatDate(dateStr: string): string {
@@ -69,7 +70,7 @@ export function exportBillsToCSV(bills: Bill[], filename?: string): void {
   const rows = bills.map(bill => [
     escapeCSV(bill.name),
     escapeCSV(bill.type === 'deposit' ? 'Deposit' : 'Expense'),
-    escapeCSV(bill.varies ? `Varies (~$${(bill.avg_amount || 0).toFixed(2)})` : `$${(bill.amount || 0).toFixed(2)}`),
+    escapeCSV(bill.varies ? `Varies (~${formatCurrency(bill.avg_amount || 0)})` : formatCurrency(bill.amount || 0)),
     escapeCSV(formatDate(bill.next_due)),
     escapeCSV(formatFrequency(bill)),
     escapeCSV(bill.account || ''),
@@ -105,8 +106,8 @@ export function exportBillsToPDF(bills: Bill[], filename?: string): void {
     .reduce((sum, b) => sum + (b.varies ? (b.avg_amount || 0) : (b.amount || 0)), 0);
 
   doc.setTextColor(0);
-  doc.text(`Total Monthly Expenses: $${totalExpenses.toFixed(2)}`, 14, 38);
-  doc.text(`Total Monthly Income: $${totalDeposits.toFixed(2)}`, 14, 44);
+  doc.text(`Total Monthly Expenses: ${formatCurrency(totalExpenses)}`, 14, 38);
+  doc.text(`Total Monthly Income: ${formatCurrency(totalDeposits)}`, 14, 44);
 
   // Table
   autoTable(doc, {
@@ -115,7 +116,7 @@ export function exportBillsToPDF(bills: Bill[], filename?: string): void {
     body: bills.map(bill => [
       bill.name,
       bill.type === 'deposit' ? 'Deposit' : 'Expense',
-      bill.varies ? `~$${(bill.avg_amount || 0).toFixed(2)}` : `$${(bill.amount || 0).toFixed(2)}`,
+      bill.varies ? `~${formatCurrency(bill.avg_amount || 0)}` : formatCurrency(bill.amount || 0),
       formatDate(bill.next_due),
       formatFrequency(bill),
       bill.account || '-',
@@ -140,7 +141,7 @@ export function exportPaymentsToCSV(
   const rows = payments.map(payment => [
     escapeCSV(payment.bill_name),
     escapeCSV(formatDate(payment.payment_date)),
-    escapeCSV(`$${payment.amount.toFixed(2)}`),
+    escapeCSV(formatCurrency(payment.amount)),
   ]);
 
   const csvContent = [headers.join(','), ...rows.map(row => row.join(','))].join('\n');
@@ -187,7 +188,7 @@ export function exportPaymentsToPDF(
   const totalAmount = payments.reduce((sum, p) => sum + p.amount, 0);
   doc.setTextColor(0);
   doc.text(`Total Payments: ${payments.length}`, 14, 38);
-  doc.text(`Total Amount: $${totalAmount.toFixed(2)}`, 14, 44);
+  doc.text(`Total Amount: ${formatCurrency(totalAmount)}`, 14, 44);
 
   // Table
   autoTable(doc, {
@@ -196,12 +197,12 @@ export function exportPaymentsToPDF(
     body: payments.map(payment => [
       payment.bill_name,
       formatDate(payment.payment_date),
-      `$${payment.amount.toFixed(2)}`,
+      formatCurrency(payment.amount),
     ]),
     styles: { fontSize: 9 },
     headStyles: { fillColor: [16, 185, 129] }, // Emerald green (#10B981)
     alternateRowStyles: { fillColor: [240, 253, 244] }, // Light emerald
-    foot: [['', 'Total:', `$${totalAmount.toFixed(2)}`]],
+    foot: [['', 'Total:', formatCurrency(totalAmount)]],
     footStyles: { fillColor: [16, 185, 129], textColor: 255, fontStyle: 'bold' },
   });
 
@@ -244,7 +245,7 @@ export function printPayments(
   // Summary
   const totalAmount = payments.reduce((sum, p) => sum + p.amount, 0);
   doc.text(`Total Payments: ${payments.length}`, 14, 33);
-  doc.text(`Total Amount: $${totalAmount.toFixed(2)}`, 14, 38);
+  doc.text(`Total Amount: ${formatCurrency(totalAmount)}`, 14, 38);
 
   // Clean table with no colors
   autoTable(doc, {
@@ -253,7 +254,7 @@ export function printPayments(
     body: payments.map(payment => [
       payment.bill_name,
       formatDate(payment.payment_date),
-      `$${payment.amount.toFixed(2)}`,
+      formatCurrency(payment.amount),
     ]),
     styles: {
       fontSize: 9,
@@ -271,7 +272,7 @@ export function printPayments(
     alternateRowStyles: {
       fillColor: [255, 255, 255] // White background (no alternating colors)
     },
-    foot: [['', 'Total:', `$${totalAmount.toFixed(2)}`]],
+    foot: [['', 'Total:', formatCurrency(totalAmount)]],
     footStyles: {
       fillColor: [255, 255, 255], // White background
       textColor: [0, 0, 0], // Black text
@@ -306,8 +307,8 @@ export function printBills(bills: Bill[]): void {
     .filter(b => b.type === 'deposit' && !b.archived)
     .reduce((sum, b) => sum + (b.varies ? (b.avg_amount || 0) : (b.amount || 0)), 0);
 
-  doc.text(`Total Monthly Expenses: $${totalExpenses.toFixed(2)}`, 14, 33);
-  doc.text(`Total Monthly Income: $${totalDeposits.toFixed(2)}`, 14, 38);
+  doc.text(`Total Monthly Expenses: ${formatCurrency(totalExpenses)}`, 14, 33);
+  doc.text(`Total Monthly Income: ${formatCurrency(totalDeposits)}`, 14, 38);
 
   // Clean table with no colors
   autoTable(doc, {
@@ -316,7 +317,7 @@ export function printBills(bills: Bill[]): void {
     body: bills.map(bill => [
       bill.name,
       bill.type === 'deposit' ? 'Deposit' : 'Expense',
-      bill.varies ? `~$${(bill.avg_amount || 0).toFixed(2)}` : `$${(bill.amount || 0).toFixed(2)}`,
+      bill.varies ? `~${formatCurrency(bill.avg_amount || 0)}` : formatCurrency(bill.amount || 0),
       formatDate(bill.next_due),
       formatFrequency(bill),
       bill.account || '-',

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,8 @@ services:
       - DATABASE_URL=postgresql://billsuser:billspass@db:5432/billsdb
       - FLASK_SECRET_KEY=dev-secret-key-change-in-prod
       - DEPLOYMENT_MODE=self-hosted
+      - DEFAULT_CURRENCY=${DEFAULT_CURRENCY:-USD}
+      - DEFAULT_LOCALE=${DEFAULT_LOCALE:-en-US}
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,10 @@ services:
       # Deployment mode (self-hosted or saas)
       - DEPLOYMENT_MODE=self-hosted
 
+      # Bill amount formatting (ISO 4217 currency and BCP 47 locale)
+      - DEFAULT_CURRENCY=${DEFAULT_CURRENCY:-USD}
+      - DEFAULT_LOCALE=${DEFAULT_LOCALE:-en-US}
+
       # Registration settings (optional)
       # - ENABLE_REGISTRATION=true  # Allow public registration
       # - REQUIRE_EMAIL_VERIFICATION=true  # Require email verification


### PR DESCRIPTION
### Summary

Adds a `DEFAULT_CURRENCY` / `DEFAULT_LOCALE` environment variable pair so self-hosted instances outside the US can display amounts in their own currency instead of the hardcoded `USD`/`en-US` formatting. Related to #[FR issue number].

### Changes

**Backend**
- `apps/server/config.py`: new `DEFAULT_CURRENCY` (default `USD`) and `DEFAULT_LOCALE` (default `en-US`) env vars, exposed via the existing `/api/v2/config` public config endpoint.

**Frontend**
- New shared utility `apps/web/src/lib/currency.ts`:
  - `formatCurrency(value)` – full currency formatting (e.g. `1.234,56 €`)
  - `formatCurrencyAxis(value)` – no-decimal variant for chart axis ticks
  - `getCurrencySymbol()` – bare symbol for `NumberInput` prefixes (e.g. `€`)
  - `setCurrencyConfig(locale, currency)` – called once by `ConfigProvider` on config load; falls back safely to `en-US`/`USD` on an invalid locale/currency combination
- `ConfigContext` / `api/client.ts`: `AppConfig` extended with `default_currency` / `default_locale`.
- Replaced every hardcoded `Intl.NumberFormat('en-US', { currency: 'USD' })`, `$${x.toFixed(2)}`, and `prefix="$"` across the app (dashboard, analytics, bill list, payments, sharing, CSV/PDF export — ~20 files) with the shared utility, so the whole UI respects the configured currency consistently.

### Out of scope (intentional)

- `Billing.tsx` (SaaS subscription pricing) stays hardcoded in USD — it mirrors fixed Stripe price IDs and isn't the self-hosted instance's bill currency.
- Language/i18n (English-only UI strings) is a separate, larger effort and not part of this PR.

### Testing

- `tsc -b` — no type errors
- `vite build` — builds successfully
- Manually verified `DEFAULT_CURRENCY=EUR` / `DEFAULT_LOCALE=de-DE` renders `1.234,56 €`-style formatting across dashboard, analytics, bill list, payment history, and CSV/PDF exports.

Refs #41