### PR TITLE
Refresh mobile libraries

### DIFF
--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -8,28 +8,24 @@
       "name": "@billmanager/mobile",
       "version": "1.0.0-alpha",
       "dependencies": {
-        "@gluestack-ui/nativewind-utils": "^1.0.28",
-        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/datetimepicker": "9.1.0",
-        "@react-navigation/bottom-tabs": "^7.9.0",
-        "@react-navigation/native": "^7.1.26",
-        "@react-navigation/native-stack": "^7.9.0",
-        "axios": "^1.16.0",
-        "babel-preset-expo": "~57.0.0",
+        "@react-navigation/bottom-tabs": "^7.18.8",
+        "@react-navigation/native": "^7.3.8",
+        "@react-navigation/native-stack": "^7.17.10",
+        "axios": "^1.18.1",
+        "babel-preset-expo": "~57.0.2",
         "expo": "~57.0.4",
-        "expo-device": "~57.0.0",
         "expo-notifications": "~57.0.3",
         "expo-secure-store": "~57.0.0",
         "expo-splash-screen": "~57.0.2",
         "expo-status-bar": "~57.0.0",
-        "lucide-react-native": "^0.562.0",
-        "nativewind": "^4.2.1",
+        "lucide-react-native": "^1.24.0",
+        "nativewind": "^4.2.6",
         "react": "19.2.3",
         "react-native": "0.86.0",
         "react-native-chart-kit": "^6.12.0",
         "react-native-gesture-handler": "~2.32.0",
-        "react-native-gifted-charts": "^1.4.70",
-        "react-native-linear-gradient": "^2.8.3",
+        "react-native-gifted-charts": "^1.4.77",
         "react-native-reanimated": "4.5.0",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
@@ -38,9 +34,9 @@
         "tailwindcss": "^3.4.17"
       },
       "devDependencies": {
-        "@types/react": "~19.2.4",
+        "@types/react": "~19.2.17",
         "typescript": "~6.0.3",
-        "vitest": "^4.1.0"
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=24.18.0 <25"
@@ -2080,18 +2076,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@gluestack-ui/nativewind-utils": {
-      "version": "1.0.28",
-      "dependencies": {
-        "find-yarn-workspace-root": "^2.0.0",
-        "patch-package": "8.0.0",
-        "tailwind-variants": "0.1.20"
-      },
-      "peerDependencies": {
-        "nativewind": ">=4.0",
-        "react": ">=16"
-      }
-    },
     "node_modules/@isaacs/ttlcache": {
       "version": "1.4.1",
       "license": "ISC",
@@ -2281,16 +2265,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@react-native-async-storage/async-storage": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "merge-options": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-community/datetimepicker": {
@@ -3199,10 +3173,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@yarnpkg/lockfile": {
-      "version": "1.1.0",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "license": "MIT",
@@ -3341,13 +3311,6 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "license": "MIT"
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/axios": {
       "version": "1.18.1",
@@ -3539,10 +3502,6 @@
       "version": "1.2.3",
       "license": "MIT"
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "funding": [
@@ -3688,22 +3647,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "license": "MIT",
@@ -3713,20 +3656,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -4037,10 +3966,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
     "node_modules/connect": {
       "version": "3.7.0",
       "license": "MIT",
@@ -4193,21 +4118,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -4537,18 +4447,6 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo-device": {
-      "version": "57.0.0",
-      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-57.0.0.tgz",
-      "integrity": "sha512-XiTtUhyS64xO8AtEY14FI1vJpUT5b+cyxhjAsHIsoAx6y4rLF719pVY2sNx1MJYb/l7qa9kxWAcMDfk8Q8Gcpg==",
-      "license": "MIT",
-      "dependencies": {
-        "ua-parser-js": "^0.7.33"
-      },
-      "peerDependencies": {
-        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -5221,13 +5119,6 @@
       "version": "2.0.0",
       "license": "MIT"
     },
-    "node_modules/find-yarn-workspace-root": {
-      "version": "2.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "micromatch": "^4.0.2"
-      }
-    },
     "node_modules/flow-enums-runtime": {
       "version": "0.0.6",
       "license": "MIT"
@@ -5280,23 +5171,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -5428,16 +5302,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -5583,14 +5447,6 @@
         "node": ">=16.x"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
@@ -5673,13 +5529,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "license": "MIT",
@@ -5689,10 +5538,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5926,23 +5771,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-stable-stringify": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "isarray": "^2.0.5",
-        "jsonify": "^0.0.1",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "license": "MIT",
@@ -5951,30 +5779,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.1",
-      "license": "Public Domain",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/klaw-sync": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -6322,7 +6126,9 @@
       }
     },
     "node_modules/lucide-react-native": {
-      "version": "0.562.0",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/lucide-react-native/-/lucide-react-native-1.24.0.tgz",
+      "integrity": "sha512-4nfHfK75Azty3bilbuW1tzgi0kqG4eHFIex7x2hP2MMNM4CuRDo9+4PEtKKoImXiFSMc7J0BeOixZlz6Ucm9VA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -6365,16 +6171,6 @@
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "license": "MIT"
-    },
-    "node_modules/merge-options": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -6794,13 +6590,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "license": "ISC",
@@ -6960,13 +6749,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -6995,13 +6777,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -7083,168 +6858,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/patch-package": {
-      "version": "8.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^4.1.2",
-        "ci-info": "^3.7.0",
-        "cross-spawn": "^7.0.3",
-        "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^9.0.0",
-        "json-stable-stringify": "^1.0.2",
-        "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.6",
-        "open": "^7.4.2",
-        "rimraf": "^2.6.3",
-        "semver": "^7.5.3",
-        "slash": "^2.0.0",
-        "tmp": "^0.0.33",
-        "yaml": "^2.2.2"
-      },
-      "bin": {
-        "patch-package": "index.js"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">5"
-      }
-    },
-    "node_modules/patch-package/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/patch-package/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/patch-package/node_modules/chalk": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/patch-package/node_modules/ci-info": {
-      "version": "3.9.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/patch-package/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/patch-package/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "node_modules/patch-package/node_modules/glob": {
-      "version": "7.2.3",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/patch-package/node_modules/has-flag": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/patch-package/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/patch-package/node_modules/rimraf": {
-      "version": "2.7.1",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/patch-package/node_modules/slash": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/patch-package/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -8043,16 +7656,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/react-native-linear-gradient": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.8.3.tgz",
-      "integrity": "sha512-KflAXZcEg54PXkLyflaSZQ3PJp4uC4whM7nT/Uot9m0e/qxFV3p6uor1983D1YOBJbJN7rrWdqIjq0T42jOJyA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-reanimated": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.5.0.tgz",
@@ -8481,21 +8084,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "license": "ISC"
@@ -8780,28 +8368,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tailwind-merge": {
-      "version": "1.14.0",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
-      }
-    },
-    "node_modules/tailwind-variants": {
-      "version": "0.1.20",
-      "license": "MIT",
-      "dependencies": {
-        "tailwind-merge": "^1.14.0"
-      },
-      "engines": {
-        "node": ">=16.x",
-        "pnpm": ">=7.x"
-      },
-      "peerDependencies": {
-        "tailwindcss": "*"
-      }
-    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -8975,15 +8541,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tmp": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
-      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "license": "BSD-3-Clause"
@@ -9044,30 +8601,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "0.7.41",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "license": "MIT"
@@ -9102,13 +8635,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -9502,10 +9028,6 @@
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
       "license": "MIT"
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "7.5.11",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,28 +21,24 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@gluestack-ui/nativewind-utils": "^1.0.28",
-    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "9.1.0",
-    "@react-navigation/bottom-tabs": "^7.9.0",
-    "@react-navigation/native": "^7.1.26",
-    "@react-navigation/native-stack": "^7.9.0",
-    "axios": "^1.16.0",
-    "babel-preset-expo": "~57.0.0",
+    "@react-navigation/bottom-tabs": "^7.18.8",
+    "@react-navigation/native": "^7.3.8",
+    "@react-navigation/native-stack": "^7.17.10",
+    "axios": "^1.18.1",
+    "babel-preset-expo": "~57.0.2",
     "expo": "~57.0.4",
-    "expo-device": "~57.0.0",
     "expo-notifications": "~57.0.3",
     "expo-secure-store": "~57.0.0",
     "expo-splash-screen": "~57.0.2",
     "expo-status-bar": "~57.0.0",
-    "lucide-react-native": "^0.562.0",
-    "nativewind": "^4.2.1",
+    "lucide-react-native": "^1.24.0",
+    "nativewind": "^4.2.6",
     "react": "19.2.3",
     "react-native": "0.86.0",
     "react-native-chart-kit": "^6.12.0",
     "react-native-gesture-handler": "~2.32.0",
-    "react-native-gifted-charts": "^1.4.70",
-    "react-native-linear-gradient": "^2.8.3",
+    "react-native-gifted-charts": "^1.4.77",
     "react-native-reanimated": "4.5.0",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",
@@ -51,9 +47,9 @@
     "tailwindcss": "^3.4.17"
   },
   "devDependencies": {
-    "@types/react": "~19.2.4",
+    "@types/react": "~19.2.17",
     "typescript": "~6.0.3",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.10"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- update React Navigation, Axios, NativeWind, Gifted Charts, Vitest, Expo Babel preset, and React type ranges
- migrate Lucide React Native from 0.562 to 1.24
- remove four unused direct dependencies: Gluestack NativeWind utilities, Async Storage, Expo Device, and React Native Linear Gradient
- keep Expo-managed native packages pinned to the SDK 57 compatibility matrix

## Verification
- `npm ci`
- `npx expo-doctor`: 20/20 checks passed
- `npx expo install --check`: dependencies are up to date
- `npx tsc --noEmit`
- `npm test`: 3 passed
- `npx expo export --platform android`
- `npm audit --audit-level=low`: 0 vulnerabilities
