### PR TITLE
Raise Python tooling dependency floors

### DIFF
--- a/apps/server/requirements.txt
+++ b/apps/server/requirements.txt
@@ -15,10 +15,10 @@ authlib>=1.7.2
 webauthn>=3.0.0
 
 # Testing
-pytest>=8.0.0
-pytest-cov>=4.1.0
-responses>=0.25.0
+pytest>=9.1.1
+pytest-cov>=7.1.0
+responses>=0.26.2
 
 # Security scanning
-bandit>=1.7.0
-pip-audit>=2.7.0
+bandit>=1.9.4
+pip-audit>=2.10.1


### PR DESCRIPTION
## Summary
- raise pytest to 9.1.1 and pytest-cov to 7.1.0
- raise responses to 0.26.2
- raise Bandit to 1.9.4 and pip-audit to 2.10.1
- leave production dependencies unchanged because they are already current

## Verification
- fresh Python 3.12 virtualenv install from `apps/server/requirements.txt`
- `pip check`: no broken requirements
- backend pytest suite: 82 passed
- `pip-audit -r apps/server/requirements.txt`: no known vulnerabilities
- `bandit -r . -x tests -c bandit.yaml -f txt`: no issues identified

GitHub CI repeats these checks on Python 3.12; the production container runtime is handled separately.
