### PR TITLE
Upgrade React Native Chart Kit to 7

### DIFF
--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -23,7 +23,7 @@
         "nativewind": "^4.2.6",
         "react": "19.2.3",
         "react-native": "0.86.0",
-        "react-native-chart-kit": "^6.12.0",
+        "react-native-chart-kit": "^7.0.2",
         "react-native-gesture-handler": "~2.32.0",
         "react-native-gifted-charts": "^1.4.77",
         "react-native-reanimated": "4.5.0",
@@ -6956,12 +6956,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/point-in-polygon": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
-      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
-      "license": "MIT"
-    },
     "node_modules/postcss": {
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
@@ -7309,18 +7303,24 @@
       }
     },
     "node_modules/react-native-chart-kit": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/react-native-chart-kit/-/react-native-chart-kit-6.12.3.tgz",
-      "integrity": "sha512-Wc7akObFaa7wAF42JGSvmd25OUpngLy412aIgJIjkmOMy3jBoPEX/yu8OPiSV3F2bSliWqlAcaqOrxuKIJy5Iw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-chart-kit/-/react-native-chart-kit-7.0.2.tgz",
+      "integrity": "sha512-rN2Q7Dak8FFC1clbkkTu7eF9gWBovYD45Fnb64hFmlxn0bYmWFv9MwG+KlNGXsmfrxZ3oU4EUbf5gOTjHtcpoQ==",
       "license": "MIT",
+      "workspaces": [
+        "packages/*",
+        "apps/site"
+      ],
       "dependencies": {
-        "paths-js": "^0.4.10",
-        "point-in-polygon": "^1.0.1"
+        "paths-js": "^0.4.11"
+      },
+      "engines": {
+        "node": ">=20.19.4"
       },
       "peerDependencies": {
-        "react": "> 16.7.0",
-        "react-native": ">= 0.50.0",
-        "react-native-svg": "> 6.4.1"
+        "react": ">=19.1.0 <20",
+        "react-native": ">=0.81 <1",
+        "react-native-svg": ">=15.12.1 <16"
       }
     },
     "node_modules/react-native-css-interop": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -36,7 +36,7 @@
     "nativewind": "^4.2.6",
     "react": "19.2.3",
     "react-native": "0.86.0",
-    "react-native-chart-kit": "^6.12.0",
+    "react-native-chart-kit": "^7.0.2",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-gifted-charts": "^1.4.77",
     "react-native-reanimated": "4.5.0",


### PR DESCRIPTION
## Summary
- upgrade `react-native-chart-kit` from 6.12 to 7.0.2
- retain the supported root compatibility import used by the existing Stats screen
- leave adoption of the new `react-native-chart-kit/v2` API for a product-focused chart redesign

## Compatibility
- the package explicitly preserves root imports for legacy screens
- BillManager's React 19.2, React Native 0.86, and React Native SVG 15.15 versions satisfy the new peer ranges

## Verification
- `npm ci`
- `npx tsc --noEmit`
- `npm test`: 3 passed
- `npx expo-doctor`: 20/20 checks passed
- `npx expo install --check`: dependencies are up to date
- `npx expo export --platform android`
- `npm audit --audit-level=low`: 0 vulnerabilities
