### PR TITLE
Align Python and PostgreSQL runtimes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: billsuser
           POSTGRES_PASSWORD: billspass
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: apps/server/requirements.txt
 
@@ -102,7 +102,7 @@ jobs:
       - name: Run npm audit
         run: |
           cd apps/web
-          npm audit --audit-level=high || true
+          npm audit --audit-level=high
 
   security-scan:
     name: Secrets Scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY apps/web/ ./
 RUN npm run build && ls -la dist/ && test -f dist/index.html
 
 # Stage 2: Python backend with built frontend
-FROM python:3.13-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- upgrade the production image and CI from Python 3.13/3.12 to Python 3.14
- align the disposable CI database with the supported PostgreSQL 17 compose runtime
- make high-severity frontend npm audit findings fail CI instead of being ignored
- leave persistent PostgreSQL images on 17; PostgreSQL 18 requires a planned data migration

## Verification

- `docker build --pull --progress=plain -t billmanager:runtime-compat-20260710 .`
- `docker run --rm --entrypoint python billmanager:runtime-compat-20260710 --version` -> Python 3.14.6
- backend test suite in the built image -> 82 passed
- frontend production build completed in the Docker build
