### PR TITLE
Add Settings link to sidebar navigation

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { Stack, Title, Text, Group, Badge, Divider, NavLink } from '@mantine/core';
-import { IconCalendar, IconHome, IconReceipt, IconChartPie, IconListDetails, IconShare } from '@tabler/icons-react';
+import { IconCalendar, IconHome, IconReceipt, IconChartPie, IconListDetails, IconShare, IconSettings } from '@tabler/icons-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { Bill } from '../api/client';
@@ -128,6 +128,13 @@ export function Sidebar({ bills, isLoggedIn, filter, onFilterChange }: SidebarPr
             leftSection={<IconShare size={16} />}
             active={location.pathname === '/settlements'}
             onClick={() => navigate('/settlements')}
+            variant="light"
+          />
+          <NavLink
+            label={t('sidebar.navSettings')}
+            leftSection={<IconSettings size={16} />}
+            active={location.pathname === '/settings'}
+            onClick={() => navigate('/settings')}
             variant="light"
           />
           <Divider my="xs" />

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -339,6 +339,7 @@
     "navCalendar": "Kalender",
     "navAnalytics": "Analysen",
     "navSettlements": "Ausgleich",
+    "navSettings": "Einstellungen",
     "upcomingBillsTitle": "Anstehende Rechnungen",
     "thisWeek": "Diese Woche",
     "nextWeek": "Nächste Woche",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -339,6 +339,7 @@
     "navCalendar": "Calendar",
     "navAnalytics": "Analytics",
     "navSettlements": "Settlements",
+    "navSettings": "Settings",
     "upcomingBillsTitle": "Upcoming Bills",
     "thisWeek": "This week",
     "nextWeek": "Next week",


### PR DESCRIPTION
The Settings page (language, 2FA, linked accounts) was only reachable by typing /settings directly; no nav link pointed to it.