### PR TITLE
Update weekly dependency maintenance

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -5668,9 +5668,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [


### PR DESCRIPTION
Summary:
- Refreshes the web lockfile from eslint 10.6.0 to 10.7.0.
- Confirms Dependabot/security queues are empty.
- Leaves major/runtime and Expo-managed freshness items for planned migrations.

Verification passed:
- web npm ci, test, lint, build, audit
- mobile npm ci, test, expo install check, audit
- backend pytest, bandit, pip-audit, pip check

Notes: web lint has four existing warnings and zero errors; npm 11 reports a core-js allow-scripts review warning during web install.