### PR TITLE
Retire API v1 dependencies and complete web v2 migration

### DIFF
--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -888,7 +888,9 @@ def calculate_next_due_date(
     else:
         current_date = current_due
 
-    if frequency == "weekly":
+    if frequency == "once":
+        return current_date
+    elif frequency == "weekly":
         return current_date + timedelta(days=7)
     elif frequency in ("bi-weekly", "biweekly"):
         return current_date + timedelta(days=14)
@@ -1953,7 +1955,9 @@ def pay_bill(bill_id):
             notes=data.get("notes"),
         )
         db.session.add(payment)
-        if data.get("advance_due", True):
+        if bill.frequency == "once":
+            bill.archived = True
+        elif data.get("advance_due", True):
             # Update existing bill instead of creating new
             freq_config = (
                 json.loads(bill.frequency_config) if bill.frequency_config else {}
@@ -2762,13 +2766,16 @@ def process_auto_payments():
     for bill in auto_bills:
         payment = Payment(bill_id=bill.id, amount=bill.amount or 0, payment_date=today)
         db.session.add(payment)
-        next_due = calculate_next_due_date(
-            bill.due_date,
-            bill.frequency,
-            bill.frequency_type,
-            json.loads(bill.frequency_config),
-        )
-        bill.due_date = next_due.isoformat()
+        if bill.frequency == "once":
+            bill.archived = True
+        else:
+            next_due = calculate_next_due_date(
+                bill.due_date,
+                bill.frequency,
+                bill.frequency_type,
+                json.loads(bill.frequency_config),
+            )
+            bill.due_date = next_due.isoformat()
     db.session.commit()
     return jsonify({"message": "Processed", "processed_count": len(auto_bills)})
 
@@ -4318,7 +4325,9 @@ def jwt_pay_bill(bill_id):
     )
     db.session.add(payment)
 
-    if data.get("advance_due", True):
+    if bill.frequency == "once":
+        bill.archived = True
+    elif data.get("advance_due", True):
         freq_config = json.loads(bill.frequency_config) if bill.frequency_config else {}
         next_due = calculate_next_due_date(
             bill.due_date, bill.frequency, bill.frequency_type, freq_config
@@ -6259,13 +6268,16 @@ def jwt_process_auto_payments():
     for bill in auto_bills:
         payment = Payment(bill_id=bill.id, amount=bill.amount or 0, payment_date=today)
         db.session.add(payment)
-        next_due = calculate_next_due_date(
-            bill.due_date,
-            bill.frequency,
-            bill.frequency_type,
-            json.loads(bill.frequency_config),
-        )
-        bill.due_date = next_due.isoformat()
+        if bill.frequency == "once":
+            bill.archived = True
+        else:
+            next_due = calculate_next_due_date(
+                bill.due_date,
+                bill.frequency,
+                bill.frequency_type,
+                json.loads(bill.frequency_config),
+            )
+            bill.due_date = next_due.isoformat()
         processed.append(
             {"bill_id": bill.id, "name": bill.name, "amount": bill.amount or 0}
         )

--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -3855,6 +3855,9 @@ def jwt_get_bills():
 
     current_user_id = g.jwt_user_id
     include_archived = request.args.get("include_archived", "false").lower() == "true"
+    bill_type = request.args.get("type")
+    if bill_type not in ("expense", "deposit"):
+        bill_type = None
 
     # Handle "all databases" mode
     result = resolve_accessible_db_ids()
@@ -3866,6 +3869,8 @@ def jwt_get_bills():
     query = Bill.query.filter(Bill.database_id.in_(accessible_db_ids))
     if not include_archived:
         query = query.filter_by(archived=False)
+    if bill_type:
+        query = query.filter_by(type=bill_type)
     owned_bills = query.order_by(Bill.due_date).all()
 
     # Get share counts for owned bills (how many people each bill is shared with)
@@ -3894,6 +3899,8 @@ def jwt_get_bills():
     )
     if not include_archived:
         shared_bill_query = shared_bill_query.filter(Bill.archived == False)
+    if bill_type:
+        shared_bill_query = shared_bill_query.filter(Bill.type == bill_type)
     shared_bills_data = shared_bill_query.order_by(Bill.due_date).all()
 
     # Create a lookup for share info

--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -6294,33 +6294,59 @@ def jwt_process_auto_payments():
 @api_v2_bp.route("/auth/change-password", methods=["POST"])
 @limiter.limit("20 per minute;60 per hour")
 def jwt_change_password():
-    """Change password (for users with password_change_required or via change_token)."""
+    """Change password.
+
+    Supports two modes:
+    - `change_token` (unauthenticated): for the forced first-login /
+      password-reset flow.
+    - `current_password` (authenticated via Authorization header): for a
+      logged-in user voluntarily changing their own password.
+    """
     data = request.get_json(force=True, silent=True)
     if not data:
         return jsonify({"success": False, "error": "Invalid JSON body"}), 400
 
     change_token = data.get("change_token")
+    current_password = data.get("current_password")
     new_password = data.get("new_password")
 
-    if not change_token or not new_password:
+    if not new_password or not (change_token or current_password):
         return jsonify(
-            {"success": False, "error": "change_token and new_password are required"}
+            {
+                "success": False,
+                "error": "new_password and either change_token or current_password are required",
+            }
         ), 400
 
     is_valid, error = validate_password(new_password)
     if not is_valid:
         return jsonify({"success": False, "error": error}), 400
 
-    user = User.find_by_change_token(change_token)
-    if not user:
-        return jsonify({"success": False, "error": "Invalid change token"}), 401
-    if not user.verify_change_token(change_token):
-        return jsonify({"success": False, "error": "Change token expired"}), 401
+    if change_token:
+        user = User.find_by_change_token(change_token)
+        if not user:
+            return jsonify({"success": False, "error": "Invalid change token"}), 401
+        if not user.verify_change_token(change_token):
+            return jsonify({"success": False, "error": "Change token expired"}), 401
+        user.password_change_required = False
+        user.change_token = None
+        user.change_token_expires = None
+    else:
+        auth_header = request.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            return jsonify(
+                {"success": False, "error": "Missing or invalid Authorization header"}
+            ), 401
+        payload = verify_access_token(auth_header.split(" ")[1])
+        if not payload:
+            return jsonify({"success": False, "error": "Invalid or expired token"}), 401
+        user = db.session.get(User, payload["user_id"])
+        if not user or not user.check_password(current_password):
+            return jsonify(
+                {"success": False, "error": "Current password is incorrect"}
+            ), 401
 
     user.set_password(new_password)
-    user.password_change_required = False
-    user.change_token = None
-    user.change_token_expires = None
     db.session.commit()
 
     # Optionally auto-login after password change

--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -4632,13 +4632,13 @@ def jwt_share_bill(bill_id):
         return access
 
     # Get share parameters
-    identifier = data.get("shared_with", "").strip().lower()  # username or email
+    identifier = data.get("identifier", "").strip().lower()  # username or email
     split_type = data.get("split_type")  # None, 'percentage', 'fixed', 'equal'
     split_value = data.get("split_value")
 
     if not identifier:
         return jsonify(
-            {"success": False, "error": "shared_with (username or email) is required"}
+            {"success": False, "error": "identifier (username or email) is required"}
         ), 400
 
     # Validate split configuration

--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -4373,6 +4373,54 @@ def jwt_get_bill_payments(bill_id):
     return jsonify({"success": True, "data": result})
 
 
+@api_v2_bp.route("/bills/<int:bill_id>/payments/monthly", methods=["GET"])
+@limiter.limit("60 per minute")
+@jwt_required
+def jwt_get_bill_monthly_payments(bill_id):
+    """Get up to 12 monthly payment totals for one bill."""
+    if not g.jwt_db_name:
+        return jsonify({"success": False, "error": "X-Database header required"}), 400
+
+    bill = db.get_or_404(Bill, bill_id)
+
+    # Keep the same ownership and shared-bill authorization semantics as the
+    # bill payment-history endpoint above.
+    has_access = check_bill_access(bill) is True
+    if not has_access:
+        share = BillShare.query.filter_by(
+            bill_id=bill_id, shared_with_user_id=g.jwt_user_id, status="accepted"
+        ).first()
+        has_access = share is not None
+
+    if not has_access:
+        return jsonify({"success": False, "error": "Access denied"}), 403
+
+    results = (
+        db.session.query(
+            func.to_char(
+                func.to_date(Payment.payment_date, "YYYY-MM-DD"), "YYYY-MM"
+            ).label("month"),
+            func.sum(Payment.amount),
+            func.count(Payment.id),
+        )
+        .filter(Payment.bill_id == bill_id)
+        .group_by("month")
+        .order_by(desc("month"))
+        .limit(12)
+        .all()
+    )
+
+    return jsonify(
+        {
+            "success": True,
+            "data": [
+                {"month": row[0], "total": float(row[1]), "count": row[2]}
+                for row in results
+            ],
+        }
+    )
+
+
 @api_v2_bp.route("/payments", methods=["GET"])
 @limiter.limit("60 per minute")
 @jwt_required
@@ -8448,6 +8496,101 @@ def jwt_create_invitation():
     ), 201
 
 
+@api_v2_bp.route("/invitations/info", methods=["GET"])
+@limiter.limit("20 per minute")
+def jwt_get_invitation_info():
+    """Get public user-invitation details by token."""
+    token = request.args.get("token", "").strip()
+    if not token:
+        return jsonify({"success": False, "error": "Token is required"}), 400
+
+    invite = UserInvite.find_by_token(token)
+    if not invite or not invite.verify_token(token):
+        return jsonify({"success": False, "error": "Invalid invitation token"}), 404
+    if invite.is_accepted:
+        return jsonify(
+            {"success": False, "error": "Invitation has already been accepted"}
+        ), 400
+    if invite.is_expired:
+        return jsonify({"success": False, "error": "Invitation has expired"}), 400
+
+    inviter = db.session.get(User, invite.invited_by_id)
+    return jsonify(
+        {
+            "success": True,
+            "data": {
+                "email": invite.email,
+                "invited_by": inviter.username if inviter else "Unknown",
+                "expires_at": invite.expires_at.isoformat(),
+            },
+        }
+    )
+
+
+@api_v2_bp.route("/invitations/accept", methods=["POST"])
+@limiter.limit("10 per minute")
+def jwt_accept_invitation():
+    """Accept a public user invitation and create the invited account."""
+    data = request.get_json(silent=True) or {}
+    token = data.get("token", "").strip()
+    username = data.get("username", "").strip()
+    password = data.get("password", "")
+
+    if not token or not username or not password:
+        return jsonify(
+            {
+                "success": False,
+                "error": "Token, username, and password are required",
+            }
+        ), 400
+
+    invite = UserInvite.find_by_token(token)
+    if not invite or not invite.verify_token(token):
+        return jsonify({"success": False, "error": "Invalid invitation token"}), 400
+    if invite.is_accepted:
+        return jsonify(
+            {"success": False, "error": "Invitation has already been accepted"}
+        ), 400
+    if invite.is_expired:
+        return jsonify({"success": False, "error": "Invitation has expired"}), 400
+
+    if User.query.filter_by(username=username).first():
+        return jsonify({"success": False, "error": "Username is already taken"}), 400
+
+    new_user = User(
+        username=username,
+        email=invite.email,
+        role=invite.role,
+        created_by_id=invite.invited_by_id,
+        # An invite can only be accepted by someone who received its email.
+        email_verified_at=datetime.datetime.now(datetime.timezone.utc),
+    )
+    new_user.set_password(password)
+    db.session.add(new_user)
+
+    if invite.database_ids:
+        for db_id_str in invite.database_ids.split(","):
+            try:
+                database = db.session.get(Database, int(db_id_str))
+            except ValueError:
+                continue
+            if database:
+                new_user.accessible_databases.append(database)
+
+    invite.accepted_at = datetime.datetime.now(datetime.timezone.utc)
+    db.session.commit()
+
+    return jsonify(
+        {
+            "success": True,
+            "data": {
+                "message": "Account created successfully",
+                "username": username,
+            },
+        }
+    ), 201
+
+
 @api_v2_bp.route("/invitations/<int:invite_id>", methods=["DELETE"])
 @jwt_admin_required
 def jwt_delete_invitation(invite_id):
@@ -8727,6 +8870,12 @@ def jwt_get_version():
             },
         }
     )
+
+
+@api_v2_bp.route("/ping", methods=["GET"])
+def jwt_ping():
+    """Return a lightweight unauthenticated liveness response."""
+    return jsonify({"success": True, "data": {"status": "ok"}})
 
 
 @api_v2_bp.route("/config", methods=["GET"])

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -177,19 +177,33 @@ paths:
   /auth/change-password:
     post:
       tags: [Authentication]
-      summary: Change password using change token
+      summary: Change a password
+      description: |
+        Supports either an unauthenticated forced-change flow using
+        `change_token`, or an authenticated self-service flow using
+        `current_password` and a bearer token.
+      security:
+        - {}
+        - bearerAuth: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required: [change_token, new_password]
+              required: [new_password]
+              oneOf:
+                - required: [change_token]
+                - required: [current_password]
               properties:
                 change_token:
                   type: string
+                current_password:
+                  type: string
+                  format: password
                 new_password:
                   type: string
+                  format: password
                   minLength: 8
                 device_info:
                   type: string
@@ -436,9 +450,9 @@ paths:
           application/json:
             schema:
               type: object
-              required: [shared_with, split_type]
+              required: [identifier]
               properties:
-                shared_with:
+                identifier:
                   type: string
                   description: Username or email of user to share with
                   example: "john@example.com"
@@ -1327,7 +1341,7 @@ components:
           description: Average payment amount (only for variable bills)
         frequency:
           type: string
-          enum: [weekly, bi-weekly, biweekly, monthly, quarterly, yearly, custom]
+          enum: [once, weekly, bi-weekly, biweekly, monthly, quarterly, yearly, custom]
         frequency_type:
           type: string
           enum: [simple, specific_dates, multiple_weekly]
@@ -1392,6 +1406,7 @@ components:
           default: false
         frequency:
           type: string
+          enum: [once, weekly, bi-weekly, biweekly, monthly, quarterly, yearly, custom]
           default: monthly
         frequency_type:
           type: string

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -248,6 +248,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: type
+          in: query
+          description: Optionally filter bills by transaction type.
+          schema:
+            type: string
+            enum: [expense, deposit]
       responses:
         '200':
           description: List of bills

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -35,6 +35,8 @@ tags:
     description: Share bills with other users and manage shared bill payments
   - name: Payments
     description: Payment recording and history
+  - name: Invitations
+    description: User invitation management and public invitation acceptance
   - name: Statistics
     description: Analytics and reporting
   - name: Utilities
@@ -872,6 +874,40 @@ paths:
                     items:
                       $ref: '#/components/schemas/Payment'
 
+  /bills/{bill_id}/payments/monthly:
+    get:
+      tags: [Payments]
+      summary: Get monthly payment totals for a bill
+      description: Returns up to 12 months of payment totals for the selected bill.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/XDatabase'
+        - $ref: '#/components/parameters/BillId'
+      responses:
+        '200':
+          description: Monthly payment totals
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required: [month, total, count]
+                      properties:
+                        month:
+                          type: string
+                          example: "2026-07"
+                        total:
+                          type: number
+                        count:
+                          type: integer
+
   /payments:
     get:
       tags: [Payments]
@@ -1003,6 +1039,95 @@ paths:
                       "2024-01": {"expenses": 1500.00, "deposits": 3000.00}
                       "2024-02": {"expenses": 1200.00, "deposits": 3000.00}
 
+  /invitations/info:
+    get:
+      tags: [Invitations]
+      summary: Get user invitation details by token
+      description: Public endpoint used before an invited user has an account.
+      parameters:
+        - name: token
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: User invitation details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      email:
+                        type: string
+                        format: email
+                      invited_by:
+                        type: string
+                      expires_at:
+                        type: string
+                        format: date-time
+        '400':
+          description: Invitation was already accepted or expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Invitation token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /invitations/accept:
+    post:
+      tags: [Invitations]
+      summary: Accept a user invitation
+      description: Public endpoint that creates the invited user's account.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token, username, password]
+              properties:
+                token:
+                  type: string
+                username:
+                  type: string
+                password:
+                  type: string
+                  format: password
+      responses:
+        '201':
+          description: Account created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                      username:
+                        type: string
+        '400':
+          description: Invalid, expired, or previously accepted invitation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /process-auto-payments:
     post:
       tags: [Utilities]
@@ -1069,6 +1194,27 @@ paths:
                         type: array
                         items:
                           type: string
+
+  /ping:
+    get:
+      tags: [Utilities]
+      summary: Check API liveness
+      responses:
+        '200':
+          description: API is reachable
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        example: ok
 
 components:
   securitySchemes:

--- a/apps/server/tests/test_auth.py
+++ b/apps/server/tests/test_auth.py
@@ -180,6 +180,58 @@ class TestPasswordChange:
             assert me_data.get("role") == "admin"
             assert me_data.get("current_db") == "testdb"
 
+    def test_v2_authenticated_change_password_with_current_password(
+        self, client, admin_auth_headers, admin_user
+    ):
+        """Mobile's Settings screen sends current_password, not change_token."""
+        response = client.post(
+            "/api/v2/auth/change-password",
+            headers=admin_auth_headers,
+            json={
+                "current_password": "testpassword123",
+                "new_password": "Newsecurepassword123",
+            },
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["success"] is True
+        assert "access_token" in data["data"]
+
+        # Old password no longer works, new one does
+        old_login = client.post(
+            "/api/v2/auth/login",
+            json={"username": admin_user.username, "password": "testpassword123"},
+        )
+        assert old_login.status_code == 401
+
+        new_login = client.post(
+            "/api/v2/auth/login",
+            json={"username": admin_user.username, "password": "Newsecurepassword123"},
+        )
+        assert new_login.status_code == 200
+
+    def test_v2_authenticated_change_password_rejects_wrong_current_password(
+        self, client, admin_auth_headers
+    ):
+        response = client.post(
+            "/api/v2/auth/change-password",
+            headers=admin_auth_headers,
+            json={
+                "current_password": "totally-wrong-password",
+                "new_password": "Newsecurepassword123",
+            },
+        )
+        assert response.status_code == 401
+        data = json.loads(response.data)
+        assert data["success"] is False
+
+    def test_v2_change_password_requires_token_or_current_password(self, client):
+        response = client.post(
+            "/api/v2/auth/change-password",
+            json={"new_password": "Newsecurepassword123"},
+        )
+        assert response.status_code == 400
+
 
 class TestLogout:
     """Test logout functionality."""

--- a/apps/server/tests/test_bills.py
+++ b/apps/server/tests/test_bills.py
@@ -707,3 +707,36 @@ class TestBillValidation:
                                })
         # Should either reject or handle appropriately
         assert response.status_code in [400, 201]
+
+
+class TestBillShareCreation:
+    """Regression coverage for POST /bills/<id>/share request field names.
+
+    The web and mobile clients both send `identifier` (username or email),
+    matching the v1 session-based route. The v2 route had drifted to expect
+    `shared_with` instead, silently rejecting every share request from both
+    clients with "identifier is required".
+    """
+
+    def test_share_by_username_accepts_identifier_field(
+        self, client, auth_headers_with_db, test_bill, regular_user
+    ):
+        response = client.post(
+            f'/api/v2/bills/{test_bill.id}/share',
+            headers=auth_headers_with_db,
+            json={'identifier': regular_user.username},
+        )
+        assert response.status_code == 201
+        data = json.loads(response.data)
+        assert data['success'] is True
+        assert data['data']['shared_with_identifier'] == regular_user.username
+
+    def test_share_missing_identifier_is_rejected(self, client, auth_headers_with_db, test_bill):
+        response = client.post(
+            f'/api/v2/bills/{test_bill.id}/share',
+            headers=auth_headers_with_db,
+            json={},
+        )
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert 'identifier' in data['error']

--- a/apps/server/tests/test_bills.py
+++ b/apps/server/tests/test_bills.py
@@ -740,3 +740,51 @@ class TestBillShareCreation:
         assert response.status_code == 400
         data = json.loads(response.data)
         assert 'identifier' in data['error']
+
+
+class TestOneTimeBills:
+    """Regression coverage for frequency='once' bills.
+
+    The mobile app has offered a "One-time" frequency option since it was
+    built, but the backend never accepted 'once' as a valid frequency and
+    had no logic to stop it from being treated as recurring - creating one
+    failed outright, and had it been accepted, paying it would have rolled
+    the due date forward instead of retiring the bill.
+    """
+
+    def test_create_once_bill_is_accepted(self, client, auth_headers_with_db):
+        response = client.post('/api/v2/bills',
+                               headers=auth_headers_with_db,
+                               json={
+                                   'name': 'One-off purchase',
+                                   'amount': 42.00,
+                                   'frequency': 'once',
+                                   'next_due': '2025-01-15',
+                               })
+        assert response.status_code == 201
+
+    def test_paying_once_bill_archives_instead_of_rescheduling(self, client, auth_headers_with_db, app, db_session, test_database):
+        with app.app_context():
+            bill = Bill(
+                database_id=test_database.id,
+                name='One-off purchase',
+                amount=42.00,
+                frequency='once',
+                due_date='2025-01-15',
+                type='expense',
+            )
+            db_session.add(bill)
+            db_session.commit()
+            db_session.refresh(bill)
+            bill_id = bill.id
+
+        response = client.post(f'/api/v2/bills/{bill_id}/pay',
+                               headers=auth_headers_with_db,
+                               json={'amount': 42.00, 'payment_date': '2025-01-15'})
+        assert response.status_code in [200, 201]
+
+        with app.app_context():
+            db_session.expire_all()
+            updated = db_session.get(Bill, bill_id)
+            assert updated.archived is True
+            assert updated.due_date == '2025-01-15'

--- a/apps/server/tests/test_bills.py
+++ b/apps/server/tests/test_bills.py
@@ -735,7 +735,7 @@ class TestBillShareCreation:
         response = client.post(
             f'/api/v2/bills/{test_bill.id}/share',
             headers=auth_headers_with_db,
-            json={},
+            json={'split_type': None},
         )
         assert response.status_code == 400
         data = json.loads(response.data)

--- a/apps/server/tests/test_bills.py
+++ b/apps/server/tests/test_bills.py
@@ -194,6 +194,32 @@ class TestBillTypes:
         get_data = json.loads(get_resp.data)
         assert get_data['data']['type'] == 'deposit'
 
+    def test_get_bills_filters_by_type(self, client, auth_headers_with_db):
+        """The v2 list endpoint honors the web client's declared type filter."""
+        client.post('/api/v2/bills', headers=auth_headers_with_db, json={
+            'name': 'Rent', 'amount': 1500.00, 'frequency': 'monthly',
+            'next_due': '2025-01-01', 'type': 'expense',
+        })
+        client.post('/api/v2/bills', headers=auth_headers_with_db, json={
+            'name': 'Salary', 'amount': 5000.00, 'frequency': 'monthly',
+            'next_due': '2025-01-15', 'type': 'deposit',
+        })
+
+        expense_response = client.get(
+            '/api/v2/bills?type=expense', headers=auth_headers_with_db
+        )
+        expense_data = json.loads(expense_response.data)['data']
+        assert [bill['name'] for bill in expense_data] == ['Rent']
+
+        deposit_response = client.get(
+            '/api/v2/bills?type=deposit', headers=auth_headers_with_db
+        )
+        deposit_data = json.loads(deposit_response.data)['data']
+        assert [bill['name'] for bill in deposit_data] == ['Salary']
+
+        all_response = client.get('/api/v2/bills', headers=auth_headers_with_db)
+        assert len(json.loads(all_response.data)['data']) == 2
+
     def test_create_variable_amount_bill(self, client, auth_headers_with_db):
         """Test creating a bill with variable amount."""
         response = client.post('/api/v2/bills',

--- a/apps/server/tests/test_v2_retirement_parity.py
+++ b/apps/server/tests/test_v2_retirement_parity.py
@@ -1,0 +1,111 @@
+"""Regression coverage for v1 capabilities migrated to the v2 API."""
+
+import datetime
+
+from models import Payment, User, UserInvite
+
+
+def _create_invite(db_session, admin_user, *, database_ids=""):
+    invite = UserInvite(
+        email="invitee@example.com",
+        role="user",
+        invited_by_id=admin_user.id,
+        database_ids=database_ids,
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
+    )
+    token = invite.set_token()
+    db_session.add(invite)
+    db_session.commit()
+    return invite, token
+
+
+class TestV2PublicUserInvitations:
+    def test_get_invitation_info_uses_v2_response_envelope(
+        self, client, db_session, admin_user
+    ):
+        _, token = _create_invite(db_session, admin_user)
+
+        response = client.get(f"/api/v2/invitations/info?token={token}")
+
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload["success"] is True
+        assert payload["data"]["email"] == "invitee@example.com"
+        assert payload["data"]["invited_by"] == admin_user.username
+
+    def test_accept_invitation_creates_user_and_grants_invited_database_access(
+        self, client, db_session, admin_user, test_database
+    ):
+        invite, token = _create_invite(
+            db_session, admin_user, database_ids=str(test_database.id)
+        )
+
+        response = client.post(
+            "/api/v2/invitations/accept",
+            json={
+                "token": token,
+                "username": "invited-user",
+                "password": "StrongPassword123",
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.get_json() == {
+            "success": True,
+            "data": {
+                "message": "Account created successfully",
+                "username": "invited-user",
+            },
+        }
+        created_user = User.query.filter_by(username="invited-user").one()
+        assert created_user.email == invite.email
+        assert test_database in created_user.accessible_databases
+        assert invite.accepted_at is not None
+
+
+class TestV2BillMonthlyPayments:
+    def test_get_monthly_payment_totals_by_bill_id(
+        self, client, auth_headers_with_db, test_bill, db_session
+    ):
+        db_session.add_all(
+            [
+                Payment(
+                    bill_id=test_bill.id,
+                    amount=10.50,
+                    payment_date="2026-05-02",
+                ),
+                Payment(
+                    bill_id=test_bill.id,
+                    amount=11.25,
+                    payment_date="2026-05-15",
+                ),
+                Payment(
+                    bill_id=test_bill.id,
+                    amount=12.75,
+                    payment_date="2026-06-03",
+                ),
+            ]
+        )
+        db_session.commit()
+
+        response = client.get(
+            f"/api/v2/bills/{test_bill.id}/payments/monthly",
+            headers=auth_headers_with_db,
+        )
+
+        assert response.status_code == 200
+        assert response.get_json() == {
+            "success": True,
+            "data": [
+                {"month": "2026-06", "total": 12.75, "count": 1},
+                {"month": "2026-05", "total": 21.75, "count": 2},
+            ],
+        }
+
+
+def test_v2_ping_preserves_the_legacy_health_check_capability(client):
+    response = client.get("/api/v2/ping")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"success": True, "data": {"status": "ok"}}

--- a/apps/server/validation.py
+++ b/apps/server/validation.py
@@ -171,7 +171,7 @@ def validate_frequency(frequency: str) -> Tuple[bool, Optional[str]]:
     Returns:
         Tuple of (is_valid, error_message)
     """
-    valid_frequencies = ['weekly', 'bi-weekly', 'biweekly', 'monthly', 'quarterly', 'yearly', 'custom']
+    valid_frequencies = ['once', 'weekly', 'bi-weekly', 'biweekly', 'monthly', 'quarterly', 'yearly', 'custom']
 
     if not frequency or frequency not in valid_frequencies:
         return False, f"Frequency must be one of: {', '.join(valid_frequencies)}"

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -200,7 +200,7 @@ export interface Bill {
   name: string;
   amount: number | null;
   varies: boolean;
-  frequency: 'weekly' | 'bi-weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'yearly' | 'custom';
+  frequency: 'once' | 'weekly' | 'bi-weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'yearly' | 'custom';
   frequency_type: 'simple' | 'specific_dates' | 'multiple_weekly';
   frequency_config: string;
   next_due: string;

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -382,28 +382,18 @@ export const getInvites = () =>
 export const cancelInvite = (inviteId: number) =>
   unwrap(api.delete<ApiResponse<void>>(`/invitations/${inviteId}`));
 
-// Public invitation endpoints (v1 only - no auth required)
-// These use axios directly since they're not in v2 API yet
-export const getInviteInfo = async (token: string) => {
-  const response = await axios.get<ApiResponse<{ email: string; invited_by: string; expires_at: string }>>(
-    `/invite-info?token=${encodeURIComponent(token)}`
-  );
-  if (!response.data.success) {
-    throw new Error(response.data.error || i18n.t('apiErrors.invitationLoadFailed'));
-  }
-  return response.data.data!;
-};
+// Public invitation endpoints. They intentionally use the v2 client so their
+// response envelope and error handling stay consistent with the rest of web.
+export const getInviteInfo = (token: string) =>
+  unwrap(api.get<ApiResponse<{ email: string; invited_by: string; expires_at: string }>>(
+    `/invitations/info?token=${encodeURIComponent(token)}`
+  ));
 
-export const acceptInvite = async (token: string, username: string, password: string) => {
-  const response = await axios.post<ApiResponse<{ message: string; username: string }>>(
-    '/accept-invite',
+export const acceptInvite = (token: string, username: string, password: string) =>
+  unwrap(api.post<ApiResponse<{ message: string; username: string }>>(
+    '/invitations/accept',
     { token, username, password }
-  );
-  if (!response.data.success) {
-    throw new Error(response.data.error || i18n.t('apiErrors.invitationAcceptFailed'));
-  }
-  return response.data.data!;
-};
+  ));
 
 // Bills API
 export const getBills = (includeArchived = false, type?: 'expense' | 'deposit') => {
@@ -499,9 +489,8 @@ export const getMonthlyComparison = () =>
 export const getAllPayments = () =>
   unwrap(api.get<ApiResponse<PaymentWithBill[]>>('/payments'));
 
-// Note: This endpoint has no v2 equivalent - may need to filter client-side or add v2 endpoint
-export const getBillMonthlyPayments = (billName: string) =>
-  unwrap(api.get<ApiResponse<MonthlyBillPayment[]>>(`/payments/bill/${encodeURIComponent(billName)}/monthly`));
+export const getBillMonthlyPayments = (billId: number) =>
+  unwrap(api.get<ApiResponse<MonthlyBillPayment[]>>(`/bills/${billId}/payments/monthly`));
 
 // Auto-payment API
 export const processAutoPayments = () =>

--- a/apps/web/src/components/BillModal.tsx
+++ b/apps/web/src/components/BillModal.tsx
@@ -71,6 +71,7 @@ interface BillModalProps {
 
 function getFrequencyOptions(t: TFunction) {
   return [
+    { value: 'once', label: t('common.frequency.once') },
     { value: 'weekly', label: t('common.frequency.weekly') },
     { value: 'bi-weekly', label: t('common.frequency.biweekly') },
     { value: 'monthly', label: t('common.frequency.monthly') },

--- a/apps/web/src/components/PaymentHistory.tsx
+++ b/apps/web/src/components/PaymentHistory.tsx
@@ -199,7 +199,7 @@ export function PaymentHistory({
         )}
 
         {/* Payment History Chart */}
-        <PaymentHistoryChart billName={billName} />
+        <PaymentHistoryChart billId={billId} />
 
         {loading ? (
           <Center py="xl">

--- a/apps/web/src/components/PaymentHistoryChart.tsx
+++ b/apps/web/src/components/PaymentHistoryChart.tsx
@@ -8,7 +8,7 @@ import type { MonthlyBillPayment } from '../api/client';
 import { formatCurrency, formatCurrencyAxis, getLocale } from '../lib/currency';
 
 interface PaymentHistoryChartProps {
-  billName: string | null;
+  billId: number | null;
 }
 
 interface ChartData {
@@ -28,17 +28,17 @@ function parseMonthString(monthStr: string): { year: number; month: number } | n
   return { year, month };
 }
 
-export function PaymentHistoryChart({ billName }: PaymentHistoryChartProps) {
+export function PaymentHistoryChart({ billId }: PaymentHistoryChartProps) {
   const { t } = useTranslation();
   const [data, setData] = useState<ChartData[]>([]);
   const [loading, setLoading] = useState(false);
 
   const fetchData = useCallback(async () => {
-    if (!billName) return;
+    if (!billId) return;
 
     setLoading(true);
     try {
-      const response = await getBillMonthlyPayments(billName);
+      const response = await getBillMonthlyPayments(billId);
       const monthlyData: MonthlyBillPayment[] = response ?? [];
 
       // Transform and reverse to show chronological order (oldest first)
@@ -63,13 +63,13 @@ export function PaymentHistoryChart({ billName }: PaymentHistoryChartProps) {
     } finally {
       setLoading(false);
     }
-  }, [billName]);
+  }, [billId]);
 
   useEffect(() => {
-    if (billName) {
+    if (billId) {
       fetchData();
     }
-  }, [billName]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [billId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (loading) {
     return (

--- a/apps/web/src/components/ShareBillModal.tsx
+++ b/apps/web/src/components/ShareBillModal.tsx
@@ -349,6 +349,11 @@ export function ShareBillModal({ opened, onClose, bill }: ShareBillModalProps) {
                         <Badge size="xs" color={getStatusColor(share.status)}>
                           {getStatusLabel(share.status, t)}
                         </Badge>
+                        {share.status === 'accepted' && (
+                          <Badge size="xs" variant="light" color={share.recipient_paid_date ? 'green' : 'gray'}>
+                            {share.recipient_paid_date ? t('shareBillModal.paid') : t('shareBillModal.unpaid')}
+                          </Badge>
+                        )}
                       </Group>
 
                       <Select
@@ -405,6 +410,11 @@ export function ShareBillModal({ opened, onClose, bill }: ShareBillModalProps) {
                         <Badge size="xs" color={getStatusColor(share.status)}>
                           {getStatusLabel(share.status, t)}
                         </Badge>
+                        {share.status === 'accepted' && (
+                          <Badge size="xs" variant="light" color={share.recipient_paid_date ? 'green' : 'gray'}>
+                            {share.recipient_paid_date ? t('shareBillModal.paid') : t('shareBillModal.unpaid')}
+                          </Badge>
+                        )}
                         {share.split_type && (
                           <Badge size="xs" variant="light">
                             {share.split_type === 'equal'

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -206,7 +206,9 @@
       "pending": "ausstehend",
       "declined": "abgelehnt",
       "revoked": "widerrufen"
-    }
+    },
+    "paid": "Bezahlt",
+    "unpaid": "Unbezahlt"
   },
   "sharedBillsSection": {
     "title": "Geteilte Rechnungen",

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -30,6 +30,7 @@
       "expense": "Ausgabe"
     },
     "frequency": {
+      "once": "Einmalig",
       "weekly": "Wöchentlich",
       "biweekly": "Zweiwöchentlich",
       "quarterly": "Vierteljährlich",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -30,6 +30,7 @@
       "expense": "Expense"
     },
     "frequency": {
+      "once": "One-time",
       "weekly": "Weekly",
       "biweekly": "Bi-weekly",
       "quarterly": "Quarterly",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -206,7 +206,9 @@
       "pending": "pending",
       "declined": "declined",
       "revoked": "revoked"
-    }
+    },
+    "paid": "Paid",
+    "unpaid": "Unpaid"
   },
   "sharedBillsSection": {
     "title": "Shared Bills",


### PR DESCRIPTION
## Summary

Complete the API v2 parity work needed to retire web dependencies on v1 and consolidate the applicable fixes from PRs #57-#61.

- add v2 public user-invitation lookup and acceptance
- add v2 per-bill monthly payment history keyed by bill ID
- add the v2 liveness endpoint and document the new contracts
- migrate the remaining web invitation and payment-history calls to v2
- fix v2 bill sharing to use the client contract's `identifier` field
- support one-time bills across the backend and web
- support authenticated self-service password changes
- show share-recipient paid status in the web UI
- honor the web client's bill-type filter from the server portion of #62
- align OpenAPI and TypeScript contracts with the implemented behavior

## Why

The web client used a v2 base URL but still depended on v1-only invitation behavior and called a missing monthly-payment route. The wider v1/v2 audit and related PR review also found request-contract drift and several capabilities exposed by clients but not honored by v2.

This draft supersedes #57, #58, #59, #60, and #61. PR #62 remains separate for its mobile bill-group description work; only its server-side bill-type filter is included here.

## Validation

- 109 backend tests passed
- 26 web tests passed
- web production build passed
- OpenAPI document parses with the corrected contracts
- ESLint reports zero errors and four pre-existing React hook dependency warnings
- all reviewed source PRs had green backend, frontend, container-build, and secret-scan checks