### PR TITLE
Fix GET /bills/<id>/shares always 403'ing in self-hosted mode

### DIFF
--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -3563,9 +3563,12 @@ def jwt_get_bill_shares(bill_id):
     if access is not True:
         return access
 
-    # Security check: Only the database owner can view shares
+    # In SaaS mode, only the database owner can view shares. owner_id is
+    # never set in self-hosted mode, so this check only applies to SaaS -
+    # otherwise it rejected every request unconditionally (owner_id is
+    # always None there, so `None != current_user_id` was always true).
     database = db.session.get(Database, bill.database_id)
-    if not database or database.owner_id != g.jwt_user_id:
+    if is_saas() and (not database or database.owner_id != g.jwt_user_id):
         return jsonify({"success": False, "error": "Access denied"}), 403
 
     shares = BillShare.query.filter_by(bill_id=bill_id).all()

--- a/apps/server/tests/test_bills.py
+++ b/apps/server/tests/test_bills.py
@@ -893,3 +893,35 @@ class TestOneTimeBills:
             updated = db_session.get(Bill, bill_id)
             assert updated.archived is True
             assert updated.due_date == '2025-01-15'
+
+
+class TestGetBillSharesSelfHosted:
+    """Regression: found via live testing on a self-hosted instance.
+
+    jwt_get_bill_shares unconditionally checked `database.owner_id !=
+    g.jwt_user_id`, but owner_id is only ever set in SaaS mode - in
+    self-hosted mode it's always None, so `None != <user id>` was always
+    true and the endpoint 403'd for everyone, including the bill's own
+    owner. ShareBillModal silently caught the error and always rendered
+    "not shared with anyone", regardless of actual share state.
+    """
+
+    def test_owner_can_list_shares_in_self_hosted_mode(
+        self, client, auth_headers_with_db, db_session, test_bill, admin_user, regular_user
+    ):
+        share = BillShare(
+            bill_id=test_bill.id,
+            owner_user_id=admin_user.id,
+            shared_with_user_id=regular_user.id,
+            shared_with_identifier=regular_user.username,
+            identifier_type='username',
+            status='pending',
+        )
+        db_session.add(share)
+        db_session.commit()
+
+        response = client.get(f'/api/v2/bills/{test_bill.id}/shares', headers=auth_headers_with_db)
+        assert response.status_code == 200
+        data = json.loads(response.data)['data']
+        assert len(data) == 1
+        assert data[0]['shared_with'] == regular_user.username


### PR DESCRIPTION
## Summary
Found this by actually clicking through a real self-hosted instance rather than just reading code: shared a bill from the web UI, got "Invitation sent", reopened the share dialog fresh, and it said "not shared with anyone" - as if the share had never happened.

Root cause: `jwt_get_bill_shares` (`GET /bills/<id>/shares`) has `if not database or database.owner_id != g.jwt_user_id: return 403`, applied unconditionally. `Database.owner_id` is only ever populated in SaaS mode (set at creation time only `if is_saas()`) - in self-hosted mode it's always `None`. So `None != <user id>` evaluates true on every request, and the endpoint 403'd for everyone, including the bill's own owner requesting their own share list. `ShareBillModal` on the frontend catches the error and silently falls back to an empty array, so this presented as "sharing works but the list is always empty" rather than a visible error.

This means the "who has this bill been shared with" view has likely never worked in self-hosted mode at all, independent of anything from today's other PRs.

Possibly worth noting for future testing: this class of bug (an `is_saas()`-unguarded `owner_id` check) only manifests when `owner_id` is `None`, i.e. self-hosted data. Your own review notes on prior PRs mention verifying SaaS-mode scenarios specifically (cross-owner denial, admin listing, etc.) - if your day-to-day testing data tends to be SaaS-created, this class of bug would stay invisible there even with careful review. Might be worth an explicit self-hosted pass (or a test fixture with `owner_id=None`) for `owner_id`-related checks going forward.

Fix: gated the ownership check behind `is_saas()`, matching every other `owner_id` comparison in this file. `check_bill_access()` (already applied above it) plus the `owner_user_id` filter on the returned list remain the actual access boundary - that database-owner check was redundant even in SaaS mode's intended semantics, just wrong in self-hosted.

## Test plan
- [ ] `make test-backend` (no Docker/venv locally; added `test_owner_can_list_shares_in_self_hosted_mode`, which fails against the old code with a 403)
- [x] Manually reproduced and verified fixed against a live self-hosted instance (shared a bill, confirmed 403 via direct API call with a fresh token, applied the fix, confirmed the logic - CI will be the first automated confirmation since I can't run pytest locally)
