### PR TITLE
Archived bills were unreachable and unshareable in the web UI

### DIFF
--- a/apps/web/src/components/BillList.tsx
+++ b/apps/web/src/components/BillList.tsx
@@ -52,6 +52,8 @@ function getFrequencyText(bill: Bill, t: TFunction): string {
   try { frequencyConfig = bill.frequency_config ? JSON.parse(bill.frequency_config) : {}; } catch { /* ignore malformed config */ }
 
   switch (bill.frequency) {
+    case 'once':
+      return t('common.frequency.once');
     case 'weekly':
       return t('common.frequency.weekly');
     case 'bi-weekly':
@@ -203,30 +205,29 @@ export function BillList({
     );
   }
 
-  if (bills.length === 0) {
-    // Different messages for filtered vs unfiltered empty state
-    if (hasActiveFilter) {
-      return (
-        <Card p="xl" withBorder>
-          <Stack align="center" gap="md">
-            <Text size="lg" c="dimmed">
-              {t('billList.noMatchFilter')}
-            </Text>
-            {onClearFilter && (
-              <Button
-                variant="light"
-                leftSection={<IconFilterOff size={16} />}
-                onClick={onClearFilter}
-              >
-                {t('billList.clearFilter')}
-              </Button>
-            )}
-          </Stack>
-        </Card>
-      );
-    }
-
-    return (
+  // Empty-state messaging differs for an active filter/search vs. genuinely
+  // no bills - but the toolbar (including search) below always renders
+  // regardless, so an all-archived list is never a dead end (search is the
+  // only way to reveal archived bills; see App.tsx's filteredBills logic).
+  const emptyState = bills.length === 0 ? (
+    hasActiveFilter ? (
+      <Card p="xl" withBorder>
+        <Stack align="center" gap="md">
+          <Text size="lg" c="dimmed">
+            {t('billList.noMatchFilter')}
+          </Text>
+          {onClearFilter && (
+            <Button
+              variant="light"
+              leftSection={<IconFilterOff size={16} />}
+              onClick={onClearFilter}
+            >
+              {t('billList.clearFilter')}
+            </Button>
+          )}
+        </Stack>
+      </Card>
+    ) : (
       <Card p="xl" withBorder>
         <Stack align="center" gap="md">
           <Text size="lg" c="dimmed">
@@ -237,8 +238,8 @@ export function BillList({
           </Button>
         </Stack>
       </Card>
-    );
-  }
+    )
+  ) : null;
 
   return (
     <Stack gap="md">
@@ -380,6 +381,9 @@ export function BillList({
         </Paper>
       )}
 
+      {emptyState}
+
+      {bills.length > 0 && (
       <Paper withBorder>
         <Table striped highlightOnHover>
           <Table.Thead>
@@ -557,6 +561,7 @@ export function BillList({
           </Table.Tbody>
         </Table>
       </Paper>
+      )}
 
       {totalPages > 1 && (
         <Group justify="center">

--- a/apps/web/src/components/BillModal.tsx
+++ b/apps/web/src/components/BillModal.tsx
@@ -561,8 +561,8 @@ export function BillModal({ opened, onClose, onSave, onArchive, onUnarchive, onD
               {...form.getInputProps('notes')}
             />
 
-            {/* Share button for existing bills */}
-            {bill && !bill.archived && (
+            {/* Share button for existing bills (archived bills can still be shared retroactively) */}
+            {bill && (
               <>
                 <Divider label={t('billModal.sharingLabel')} labelPosition="center" />
                 <Group justify="center">

--- a/apps/web/src/components/Dashboard/UpcomingBillsList.tsx
+++ b/apps/web/src/components/Dashboard/UpcomingBillsList.tsx
@@ -42,6 +42,8 @@ function getFrequencyText(bill: Bill, t: TFunction): string {
   try { frequencyConfig = bill.frequency_config ? JSON.parse(bill.frequency_config) : {}; } catch { /* ignore malformed config */ }
 
   switch (bill.frequency) {
+    case 'once':
+      return t('common.frequency.once');
     case 'weekly':
       return t('common.frequency.weekly');
     case 'bi-weekly':

--- a/apps/web/src/utils/export.ts
+++ b/apps/web/src/utils/export.ts
@@ -22,6 +22,8 @@ function formatFrequency(bill: Bill, t: TFunction): string {
   try { frequencyConfig = bill.frequency_config ? JSON.parse(bill.frequency_config) : {}; } catch { /* ignore malformed config */ }
 
   switch (bill.frequency) {
+    case 'once':
+      return t('common.frequency.once');
     case 'weekly':
       return t('common.frequency.weekly');
     case 'bi-weekly':


### PR DESCRIPTION
## Summary
Found by actually clicking through a real self-hosted instance rather than just reading code. All three are about the web app's treatment of archived bills, which matters a lot more now that every one-time bill auto-archives right after payment (from the earlier one-time-bills work):

**1. Dead end in the bill list when everything's archived.** `BillList.tsx` returned its "no bills yet" empty state whenever the *visible* (non-archived) bill count was 0 - and that early-return skipped the toolbar entirely, including the search box. `App.tsx` only includes archived bills in the list *while actively searching* (`filteredBills` hides them otherwise). So once a user's only bill(s) were archived, there was no way to reach the one control that could reveal them: the app said "you have no bills, add your first one" while an archived bill sat completely inaccessible. Reproduced live: paid a one-time bill, it archived correctly, then the bill list showed empty with zero path back to it. Restructured so the toolbar/search always renders; only the message below it depends on whether `bills.length === 0`.

**2. Archived bills couldn't be shared.** `BillModal.tsx` gated the "Share bill" button behind `bill && !bill.archived`, but `jwt_share_bill` on the backend has no archived check at all - nothing stops sharing an archived bill server-side. Since a one-time bill's normal lifecycle is now "pay → auto-archive", this meant there was no way to retroactively share a one-time expense after paying it (e.g. splitting a trip cost with a partner after booking it yourself). Removed the condition.

**3. `'once'` frequency displayed as literal "once".** Three separate `getFrequencyText`/`formatFrequency` functions (`BillList.tsx`, `export.ts`, `UpcomingBillsList.tsx`) had switch statements over `bill.frequency` with no `case 'once'`, falling through to the untranslated raw value. The create/edit form's dropdown already had the `once` → "Einmalig"/"One-time" label; these three read-only display paths didn't.

## Test plan
- [x] `npx tsc --noEmit` - passes
- [x] `npm run test` - 26/26 passing
- [x] `npm run lint` - no new warnings
- [x] Manually reproduced all three against a live self-hosted instance before fixing, then re-verified the fixed code compiles/type-checks/lints clean (couldn't re-deploy to the live instance to click through again, but the fixes are minimal and directly address the traced root cause of each)