### PR TITLE
Reminder alerts drawer was entirely untranslated

### DIFF
--- a/apps/mobile/src/i18n/locales/de.json
+++ b/apps/mobile/src/i18n/locales/de.json
@@ -363,7 +363,19 @@
     "closeAriaLabel": "Erinnerungen schließen",
     "alertCount_one": "{{count}} Erinnerung",
     "alertCount_other": "{{count}} Erinnerungen",
-    "clickToReview": "Zum Überprüfen klicken"
+    "clickToReview": "Zum Überprüfen klicken",
+    "titleOverdue": "{{name}} ist überfällig",
+    "titleDueToday": "{{name}} ist heute fällig",
+    "titleDepositToday": "{{name}} wird heute erwartet",
+    "titleDueInDays_one": "{{name}} fällig in {{count}} Tag",
+    "titleDueInDays_other": "{{name}} fällig in {{count}} Tagen",
+    "titleDepositInDays_one": "{{name}} erwartet in {{count}} Tag",
+    "titleDepositInDays_other": "{{name}} erwartet in {{count}} Tagen",
+    "messageOverdue_one": "Vor {{count}} Tag fällig gewesen",
+    "messageOverdue_other": "Vor {{count}} Tagen fällig gewesen",
+    "messageRecordPayment": "Zahlung erfassen, sobald erledigt",
+    "messageDepositToday": "Erwartete Einzahlung ist heute fällig",
+    "messageUpcomingWindow": "Bevorstehendes Erinnerungsfenster"
   },
   "iconPicker": {
     "title": "Symbol auswählen",

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -363,7 +363,19 @@
     "closeAriaLabel": "Close reminder alerts",
     "alertCount_one": "{{count}} Reminder Alert",
     "alertCount_other": "{{count}} Reminder Alerts",
-    "clickToReview": "Click to review"
+    "clickToReview": "Click to review",
+    "titleOverdue": "{{name}} is overdue",
+    "titleDueToday": "{{name}} is due today",
+    "titleDepositToday": "{{name}} is expected today",
+    "titleDueInDays_one": "{{name}} due in {{count}} day",
+    "titleDueInDays_other": "{{name}} due in {{count}} days",
+    "titleDepositInDays_one": "{{name}} expected in {{count}} day",
+    "titleDepositInDays_other": "{{name}} expected in {{count}} days",
+    "messageOverdue_one": "Due {{count}} day ago",
+    "messageOverdue_other": "Due {{count}} days ago",
+    "messageRecordPayment": "Record payment when complete",
+    "messageDepositToday": "Expected deposit is due today",
+    "messageUpcomingWindow": "Upcoming reminder window"
   },
   "iconPicker": {
     "title": "Choose an Icon",

--- a/apps/web/src/__tests__/ReminderAlertsWidget.test.tsx
+++ b/apps/web/src/__tests__/ReminderAlertsWidget.test.tsx
@@ -23,11 +23,16 @@ describe('ReminderAlertsWidget', () => {
       {
         type: 'upcoming',
         bill_id: 1,
+        bill_name: 'Utilities bill',
         due_date: '2026-07-15',
+        days_until_due: 3,
         severity: 'warning',
-        title: 'Utilities bill',
+        // title/message are the backend's raw (unlocalized) fallback text -
+        // the widget derives its own localized text from type/bill_name/
+        // days_until_due instead of rendering these directly.
+        title: 'Utilities bill due in 3 day(s)',
         database_name: 'Household',
-        message: 'Due soon',
+        message: 'Upcoming reminder window',
         amount: 125,
       },
     ]);
@@ -40,7 +45,7 @@ describe('ReminderAlertsWidget', () => {
     const trigger = await screen.findByRole('button', { name: 'Open reminder alerts' });
     await user.click(trigger);
 
-    await screen.findByText('Utilities bill');
+    await screen.findByText('Utilities bill due in 3 days');
     expect(screen.queryByRole('button', { name: 'Open reminder alerts' })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Close reminder alerts' }));

--- a/apps/web/src/components/ReminderAlertsWidget.tsx
+++ b/apps/web/src/components/ReminderAlertsWidget.tsx
@@ -3,6 +3,7 @@ import { Affix, Badge, Button, Drawer, Group, Paper, Stack, Text, ThemeIcon, Uns
 import { useDisclosure } from '@mantine/hooks';
 import { IconAlertTriangle, IconBellRinging } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import type { Bill, ReminderAlert } from '../api/client';
 import { getReminderAlerts } from '../api/client';
 import { formatCurrency } from '../lib/currency';
@@ -15,6 +16,43 @@ interface ReminderAlertsWidgetProps {
 
 function alertColor(alerts: ReminderAlert[]) {
   return alerts.some((alert) => alert.severity === 'critical') ? 'red' : 'yellow';
+}
+
+// The backend's alert.title/alert.message are plain hardcoded English text
+// (not localized). Rebuild both from the structured fields instead of
+// rendering them directly, same as the create/edit form already does for
+// bill frequency labels.
+function alertTitle(alert: ReminderAlert, t: TFunction): string {
+  switch (alert.type) {
+    case 'overdue':
+      return t('reminderAlertsWidget.titleOverdue', { name: alert.bill_name });
+    case 'due_today':
+      return t('reminderAlertsWidget.titleDueToday', { name: alert.bill_name });
+    case 'deposit_today':
+      return t('reminderAlertsWidget.titleDepositToday', { name: alert.bill_name });
+    case 'upcoming':
+      return t('reminderAlertsWidget.titleDueInDays', { name: alert.bill_name, count: alert.days_until_due });
+    case 'deposit_expected':
+      return t('reminderAlertsWidget.titleDepositInDays', { name: alert.bill_name, count: alert.days_until_due });
+    default:
+      return alert.title;
+  }
+}
+
+function alertMessage(alert: ReminderAlert, t: TFunction): string {
+  switch (alert.type) {
+    case 'overdue':
+      return t('reminderAlertsWidget.messageOverdue', { count: Math.abs(alert.days_until_due) });
+    case 'due_today':
+      return t('reminderAlertsWidget.messageRecordPayment');
+    case 'deposit_today':
+      return t('reminderAlertsWidget.messageDepositToday');
+    case 'upcoming':
+    case 'deposit_expected':
+      return t('reminderAlertsWidget.messageUpcomingWindow');
+    default:
+      return alert.message;
+  }
 }
 
 export function ReminderAlertsWidget({ bills, hasDatabase, onPayBill }: ReminderAlertsWidgetProps) {
@@ -92,7 +130,7 @@ export function ReminderAlertsWidget({ bills, hasDatabase, onPayBill }: Reminder
                 <Group justify="space-between" wrap="nowrap" align="flex-start">
                   <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
                     <Group gap="xs">
-                      <Text fw={600}>{alert.title}</Text>
+                      <Text fw={600}>{alertTitle(alert, t)}</Text>
                       <Badge
                         size="xs"
                         color={alert.severity === 'critical' ? 'red' : alert.severity === 'warning' ? 'yellow' : 'blue'}
@@ -102,7 +140,7 @@ export function ReminderAlertsWidget({ bills, hasDatabase, onPayBill }: Reminder
                       </Badge>
                     </Group>
                     <Text size="sm" c="dimmed">
-                      {alert.message}
+                      {alertMessage(alert, t)}
                       {alert.amount !== null ? ` - ${formatCurrency(alert.amount)}` : ''}
                     </Text>
                   </Stack>

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -363,7 +363,19 @@
     "closeAriaLabel": "Erinnerungen schließen",
     "alertCount_one": "{{count}} Erinnerung",
     "alertCount_other": "{{count}} Erinnerungen",
-    "clickToReview": "Zum Überprüfen klicken"
+    "clickToReview": "Zum Überprüfen klicken",
+    "titleOverdue": "{{name}} ist überfällig",
+    "titleDueToday": "{{name}} ist heute fällig",
+    "titleDepositToday": "{{name}} wird heute erwartet",
+    "titleDueInDays_one": "{{name}} fällig in {{count}} Tag",
+    "titleDueInDays_other": "{{name}} fällig in {{count}} Tagen",
+    "titleDepositInDays_one": "{{name}} erwartet in {{count}} Tag",
+    "titleDepositInDays_other": "{{name}} erwartet in {{count}} Tagen",
+    "messageOverdue_one": "Vor {{count}} Tag fällig gewesen",
+    "messageOverdue_other": "Vor {{count}} Tagen fällig gewesen",
+    "messageRecordPayment": "Zahlung erfassen, sobald erledigt",
+    "messageDepositToday": "Erwartete Einzahlung ist heute fällig",
+    "messageUpcomingWindow": "Bevorstehendes Erinnerungsfenster"
   },
   "iconPicker": {
     "title": "Symbol auswählen",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -363,7 +363,19 @@
     "closeAriaLabel": "Close reminder alerts",
     "alertCount_one": "{{count}} Reminder Alert",
     "alertCount_other": "{{count}} Reminder Alerts",
-    "clickToReview": "Click to review"
+    "clickToReview": "Click to review",
+    "titleOverdue": "{{name}} is overdue",
+    "titleDueToday": "{{name}} is due today",
+    "titleDepositToday": "{{name}} is expected today",
+    "titleDueInDays_one": "{{name}} due in {{count}} day",
+    "titleDueInDays_other": "{{name}} due in {{count}} days",
+    "titleDepositInDays_one": "{{name}} expected in {{count}} day",
+    "titleDepositInDays_other": "{{name}} expected in {{count}} days",
+    "messageOverdue_one": "Due {{count}} day ago",
+    "messageOverdue_other": "Due {{count}} days ago",
+    "messageRecordPayment": "Record payment when complete",
+    "messageDepositToday": "Expected deposit is due today",
+    "messageUpcomingWindow": "Upcoming reminder window"
   },
   "iconPicker": {
     "title": "Choose an Icon",


### PR DESCRIPTION
## Summary
Found by clicking through every screen of a live instance specifically hunting for missing translations (per user request, after the earlier "Invitation sent" and "once" frequency i18n gaps). The "Erinnerungen" (reminder alerts) drawer's chrome is fully localized - title, aria labels, close button - but every alert *inside* it renders as plain English regardless of the app's language: "Gehalt expected in 3 day(s)", "Upcoming reminder window", "... is overdue", etc.

Root cause: `jwt_get_upcoming_alerts` (`GET /alerts/upcoming`) builds `title`/`message` as hardcoded English f-strings server-side (e.g. `f"{bill.name} is overdue"`, `"Upcoming reminder window"`), and `ReminderAlertsWidget.tsx` rendered `alert.title`/`alert.message` directly. Same underlying pattern as the "Invitation sent" share-response text from earlier today, just covering a whole drawer instead of one toast, and not something a quick backend string fix can solve well (no i18n infrastructure in the Python backend, and the backend has no reliable signal for the user's chosen language anyway).

Fix: derive the title/message on the frontend from the structured fields the API already returns (`alert.type`, `bill_name`, `days_until_due`) via i18next, the same way bill frequency labels are already derived from `bill.frequency` rather than trusting raw text. Backend `title`/`message` stay in place as an unused fallback for any future `alert.type` the frontend doesn't recognize yet - didn't touch the backend at all, this was purely a "don't trust the untranslated string" frontend fix. Mobile doesn't consume this endpoint (confirmed via the generated OpenAPI schema - it's typed but never called), so no mobile changes needed.

## Test plan
- [x] `npx tsc --noEmit` - passes
- [x] `npm run test` - 26/26 passing (updated the existing `ReminderAlertsWidget` test, which had been asserting on the old raw English text)
- [x] `npm run lint` - no new warnings
- [x] Manually reproduced against a live instance (paid/created bills to generate `upcoming`/`due_today` alerts, confirmed English text appeared in the German UI before the fix)