### PR TITLE
Deleting bills, users, or bill groups with share history 500s

### DIFF
--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -2943,6 +2943,12 @@ def jwt_delete_bill_permanent(bill_id):
     if conflict:
         return conflict
 
+    # share_audit_log.bill_id has no ON DELETE clause, so a bill that was
+    # ever shared (i.e. has audit history) would otherwise fail this delete
+    # with a foreign key violation. BillShare rows cascade via the Bill.shares
+    # relationship, but the audit log doesn't, so it needs explicit cleanup.
+    ShareAuditLog.query.filter_by(bill_id=bill.id).delete(synchronize_session=False)
+
     db.session.delete(bill)
     response_payload = {
         "success": True,
@@ -7403,6 +7409,43 @@ def jwt_delete_user(target_user_id):
             pass
         elif user.created_by_id is not None and user.created_by_id != current_user_id:
             return jsonify({"success": False, "error": "Access denied"}), 403
+
+    # Several tables reference users.id with no ON DELETE clause, so deleting
+    # a user who had ever logged in, sent an invite, or shared a bill would
+    # otherwise fail with a foreign key violation. Mirrors the cleanup done
+    # in jwt_delete_account, scoped to just this one user.
+    db.session.execute(
+        user_database_access.delete().where(user_database_access.c.user_id == target_user_id)
+    )
+    UserInvite.query.filter_by(invited_by_id=target_user_id).delete(synchronize_session=False)
+    RefreshToken.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    UserDevice.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    Subscription.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    OAuthAccount.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    TwoFAChallenge.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    TwoFAConfig.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    WebAuthnCredential.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    BillShare.query.filter(
+        or_(
+            BillShare.owner_user_id == target_user_id,
+            BillShare.shared_with_user_id == target_user_id,
+        )
+    ).delete(synchronize_session=False)
+    ShareAuditLog.query.filter(
+        or_(
+            ShareAuditLog.actor_user_id == target_user_id,
+            ShareAuditLog.affected_user_id == target_user_id,
+        )
+    ).delete(synchronize_session=False)
+    # Deleting this user shouldn't take other users or databases down with it;
+    # just drop the now-dangling reference to them.
+    User.query.filter_by(created_by_id=target_user_id).update(
+        {"created_by_id": None}, synchronize_session=False
+    )
+    Database.query.filter_by(owner_id=target_user_id).update(
+        {"owner_id": None}, synchronize_session=False
+    )
+
     db.session.delete(user)
     db.session.commit()
     return jsonify({"success": True, "data": {"message": "User deleted"}})
@@ -7825,6 +7868,19 @@ def jwt_delete_database(database_id):
 
     if is_saas() and database.owner_id != current_user_id:
         return jsonify({"success": False, "error": "Access denied"}), 403
+
+    # Bills cascade-delete via the Database.bills relationship, but
+    # share_audit_log.bill_id has no ON DELETE clause, so any bill in this
+    # group that was ever shared would otherwise fail the whole delete with
+    # a foreign key violation (same issue as jwt_delete_bill_permanent).
+    bill_ids = [
+        row[0]
+        for row in db.session.query(Bill.id).filter(Bill.database_id == database.id).all()
+    ]
+    if bill_ids:
+        ShareAuditLog.query.filter(ShareAuditLog.bill_id.in_(bill_ids)).delete(
+            synchronize_session=False
+        )
 
     db.session.delete(database)
     db.session.commit()

--- a/apps/server/tests/test_bills.py
+++ b/apps/server/tests/test_bills.py
@@ -10,7 +10,7 @@ import json
 import datetime
 import pytest
 
-from models import Bill, BillShare, Database
+from models import Bill, BillShare, Database, ShareAuditLog, db
 
 
 class TestBillsCRUD:
@@ -845,6 +845,56 @@ class TestBillShareCreation:
         after = client.get(f'/api/v2/bills/{test_bill.id}/shares', headers=auth_headers_with_db)
         after_data = json.loads(after.data)['data']
         assert after_data[0]['recipient_paid_date'] is not None
+
+
+class TestPermanentDeleteWithShareHistory:
+    """Regression: share_audit_log.bill_id has no ON DELETE clause, so
+    permanently deleting a bill that had ever been shared (i.e. had any
+    audit log rows) raised a Postgres IntegrityError and surfaced to users
+    as a generic server error, even though the bill's own BillShare rows
+    are cascade-deleted cleanly via the Bill.shares ORM relationship.
+    """
+
+    def test_permanently_deleting_shared_bill_does_not_500(
+        self, client, auth_headers_with_db, db_session, test_bill, admin_user, regular_user
+    ):
+        share = BillShare(
+            bill_id=test_bill.id,
+            owner_user_id=admin_user.id,
+            shared_with_user_id=regular_user.id,
+            shared_with_identifier=regular_user.username,
+            identifier_type='username',
+            status='accepted',
+            accepted_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+
+        ShareAuditLog.log_action(
+            action='created',
+            bill_id=test_bill.id,
+            actor_user_id=admin_user.id,
+            share_id=share.id,
+            affected_user_id=regular_user.id,
+        )
+        ShareAuditLog.log_action(
+            action='accepted',
+            bill_id=test_bill.id,
+            actor_user_id=regular_user.id,
+            share_id=share.id,
+            affected_user_id=admin_user.id,
+        )
+
+        response = client.delete(
+            f'/api/v2/bills/{test_bill.id}/permanent', headers=auth_headers_with_db
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['success'] is True
+
+        assert db.session.get(Bill, test_bill.id) is None
+        assert ShareAuditLog.query.filter_by(bill_id=test_bill.id).count() == 0
 
 
 class TestOneTimeBills:

--- a/apps/server/tests/test_v2_admin_parity.py
+++ b/apps/server/tests/test_v2_admin_parity.py
@@ -222,33 +222,38 @@ class TestV2UserDeletion:
         db_session.add(share)
         db_session.commit()
         db_session.refresh(share)
+        share_id = share.id
         ShareAuditLog.log_action(
-            action='created', bill_id=test_bill.id, actor_user_id=admin_user.id, share_id=share.id,
+            action='created', bill_id=test_bill.id, actor_user_id=admin_user.id, share_id=share_id,
         )
         db_session.commit()
+        admin_user_id = admin_user.id
+        regular_user_id = regular_user.id
 
         response = client.delete(
-            f'/api/v2/users/{admin_user.id}', headers=_headers_for(second_admin)
+            f'/api/v2/users/{admin_user_id}', headers=_headers_for(second_admin)
         )
         assert response.status_code == 200
         assert json.loads(response.data)['success'] is True
 
-        assert db.session.get(User, admin_user.id) is None
+        # The tables below were mutated by bulk queries (synchronize_session=False,
+        # matching jwt_delete_account's existing convention) or by another
+        # session (the Flask request), so previously-loaded ORM references
+        # (admin_user, regular_user, share) are stale/expired. Querying by
+        # the ids captured above avoids SQLAlchemy trying to refresh a
+        # now-gone row and raising ObjectDeletedError.
+        assert db.session.get(User, admin_user_id) is None
         # created_by_id is orphaned rather than blocking the delete, or
         # taking regular_user down with it
-        db_session.refresh(regular_user)
-        assert regular_user.created_by_id is None
-        assert db.session.get(User, regular_user.id) is not None
+        refreshed_regular_user = db.session.get(User, regular_user_id)
+        assert refreshed_regular_user is not None
+        assert refreshed_regular_user.created_by_id is None
         # dependent rows owned by the deleted user are cleaned up rather
         # than left dangling
-        assert RefreshToken.query.filter_by(user_id=admin_user.id).count() == 0
-        assert UserInvite.query.filter_by(invited_by_id=admin_user.id).count() == 0
-        # share.id was bulk-deleted (synchronize_session=False), so the
-        # already-loaded `share` instance is a stale identity-map entry;
-        # db.session.get() would try to refresh it and raise
-        # ObjectDeletedError instead of returning None. Query fresh instead.
-        assert BillShare.query.filter_by(id=share.id).first() is None
-        assert ShareAuditLog.query.filter_by(actor_user_id=admin_user.id).count() == 0
+        assert RefreshToken.query.filter_by(user_id=admin_user_id).count() == 0
+        assert UserInvite.query.filter_by(invited_by_id=admin_user_id).count() == 0
+        assert BillShare.query.filter_by(id=share_id).first() is None
+        assert ShareAuditLog.query.filter_by(actor_user_id=admin_user_id).count() == 0
 
 
 class TestV2DatabaseDeletionWithShareHistory:

--- a/apps/server/tests/test_v2_admin_parity.py
+++ b/apps/server/tests/test_v2_admin_parity.py
@@ -3,11 +3,20 @@ Regression tests for v2 (JWT) admin endpoints that had drifted from their
 v1 (session) counterparts: database description handling, database access
 grant/revoke, SaaS cross-account isolation, and user role-change guards.
 """
+import datetime
 import json
 
 import config
 from app import create_access_token
-from models import Database, User
+from models import (
+    BillShare,
+    Database,
+    RefreshToken,
+    ShareAuditLog,
+    User,
+    UserInvite,
+    db,
+)
 
 
 def _headers_for(user):
@@ -166,3 +175,109 @@ class TestV2UserRoleChangeGuards:
         )
         assert response.status_code == 400
         assert 'account owner' in json.loads(response.data)['error'].lower()
+
+
+class TestV2UserDeletion:
+    """Regression: several foreign keys onto users.id had no ON DELETE
+    clause (created_by_id, refresh_tokens.user_id, user_invites.invited_by_id,
+    bill_shares.owner_user_id, share_audit_log.actor_user_id), so deleting a
+    user who had ever logged in, invited someone, or shared a bill raised a
+    Postgres IntegrityError, surfaced to admins as a generic server error.
+    jwt_delete_user now cleans up the same tables jwt_delete_account already
+    did, scoped to just the one user being removed.
+    """
+
+    def test_deleting_user_with_related_history_does_not_500(
+        self, client, db_session, admin_user, regular_user, test_bill
+    ):
+        second_admin = User(
+            username='seconddeleter',
+            role='admin',
+            email='seconddeleter@test.com',
+        )
+        second_admin.set_password('pw12345678')
+        db_session.add(second_admin)
+        db_session.commit()
+
+        # admin_user created regular_user (via the fixture) -> created_by_id
+        db_session.add(RefreshToken(
+            user_id=admin_user.id,
+            token_hash='a' * 64,
+            expires_at=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1),
+        ))
+        db_session.add(UserInvite(
+            email='invitee@test.com',
+            token='b' * 64,
+            invited_by_id=admin_user.id,
+            expires_at=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=7),
+        ))
+        share = BillShare(
+            bill_id=test_bill.id,
+            owner_user_id=admin_user.id,
+            shared_with_user_id=regular_user.id,
+            shared_with_identifier=regular_user.username,
+            identifier_type='username',
+            status='accepted',
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+        ShareAuditLog.log_action(
+            action='created', bill_id=test_bill.id, actor_user_id=admin_user.id, share_id=share.id,
+        )
+        db_session.commit()
+
+        response = client.delete(
+            f'/api/v2/users/{admin_user.id}', headers=_headers_for(second_admin)
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data)['success'] is True
+
+        assert db.session.get(User, admin_user.id) is None
+        # created_by_id is orphaned rather than blocking the delete, or
+        # taking regular_user down with it
+        db_session.refresh(regular_user)
+        assert regular_user.created_by_id is None
+        assert db.session.get(User, regular_user.id) is not None
+        # dependent rows owned by the deleted user are cleaned up rather
+        # than left dangling
+        assert RefreshToken.query.filter_by(user_id=admin_user.id).count() == 0
+        assert UserInvite.query.filter_by(invited_by_id=admin_user.id).count() == 0
+        assert db.session.get(BillShare, share.id) is None
+        assert ShareAuditLog.query.filter_by(actor_user_id=admin_user.id).count() == 0
+
+
+class TestV2DatabaseDeletionWithShareHistory:
+    """Regression: deleting a bill group cascade-deletes its bills via the
+    Database.bills relationship, but share_audit_log.bill_id has no ON
+    DELETE clause, so a group containing any bill that was ever shared
+    would fail the whole delete with a foreign key violation.
+    """
+
+    def test_deleting_database_with_shared_bill_does_not_500(
+        self, client, admin_auth_headers, db_session, admin_user, regular_user, test_bill, test_database
+    ):
+        share = BillShare(
+            bill_id=test_bill.id,
+            owner_user_id=admin_user.id,
+            shared_with_user_id=regular_user.id,
+            shared_with_identifier=regular_user.username,
+            identifier_type='username',
+            status='accepted',
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+        ShareAuditLog.log_action(
+            action='created', bill_id=test_bill.id, actor_user_id=admin_user.id, share_id=share.id,
+        )
+        db_session.commit()
+
+        response = client.delete(
+            f'/api/v2/databases/{test_database.id}', headers=admin_auth_headers
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data)['success'] is True
+
+        assert db.session.get(Database, test_database.id) is None
+        assert ShareAuditLog.query.filter_by(bill_id=test_bill.id).count() == 0

--- a/apps/server/tests/test_v2_admin_parity.py
+++ b/apps/server/tests/test_v2_admin_parity.py
@@ -243,7 +243,11 @@ class TestV2UserDeletion:
         # than left dangling
         assert RefreshToken.query.filter_by(user_id=admin_user.id).count() == 0
         assert UserInvite.query.filter_by(invited_by_id=admin_user.id).count() == 0
-        assert db.session.get(BillShare, share.id) is None
+        # share.id was bulk-deleted (synchronize_session=False), so the
+        # already-loaded `share` instance is a stale identity-map entry;
+        # db.session.get() would try to refresh it and raise
+        # ObjectDeletedError instead of returning None. Query fresh instead.
+        assert BillShare.query.filter_by(id=share.id).first() is None
         assert ShareAuditLog.query.filter_by(actor_user_id=admin_user.id).count() == 0
 
 


### PR DESCRIPTION
## Summary

Several foreign keys reference `bills.id` / `users.id` with no `ON DELETE` clause: `share_audit_log.bill_id`/`actor_user_id`/`affected_user_id`, `bill_shares.owner_user_id`/`shared_with_user_id`, `refresh_tokens.user_id`, `user_invites.invited_by_id`, `subscriptions.user_id`, `users.created_by_id`, `databases.owner_id`.

That means:
- Permanently deleting a bill that was ever shared (has any `share_audit_log` rows) raised a Postgres foreign key violation, surfaced as a generic server error.
- Deleting a user who had ever logged in, sent an invite, or shared a bill did the same — `jwt_delete_user` did a bare `db.session.delete(user)` with none of the cleanup that `jwt_delete_account` already does for self-deletion.
- Deleting a whole bill group (`jwt_delete_database`) cascade-deletes its bills, so a group containing even one shared bill hit the same error.

Root-caused this from a report of "various server errors deleting bills or users" on a self-hosted instance.

## Fix

Rather than adding `ON DELETE` clauses at the schema level (which would need a migration touching live production data), this mirrors the cleanup pattern `jwt_delete_account` already uses: explicitly delete/null the dependent rows before the parent row goes away.

- `jwt_delete_bill_permanent`: clear `share_audit_log` rows for the bill before deleting it.
- `jwt_delete_database`: same, for every bill in the group.
- `jwt_delete_user`: clean up refresh tokens, devices, subscription, OAuth/2FA records, invites sent, bill shares (owned or received), and audit log entries for the target user; null out `created_by_id`/`owner_id` on any users/databases they created/owned rather than cascading further deletes.

## Test plan
- [x] Added regression tests: `TestPermanentDeleteWithShareHistory` (test_bills.py), `TestV2UserDeletion` and `TestV2DatabaseDeletionWithShareHistory` (test_v2_admin_parity.py)
- [ ] CI (backend tests run against real Postgres, so these tests actually exercise the FK constraints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)