### PR TITLE
fix: safely delete users across deployment modes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,10 +49,19 @@ jobs:
           cd apps/server
           pip install -r requirements.txt
 
-      - name: Run pytest
+      - name: Run pytest (self-hosted)
+        env:
+          DEPLOYMENT_MODE: self-hosted
         run: |
           cd apps/server
           pytest -v --cov=. --cov-report=xml --cov-report=term-missing
+
+      - name: Run pytest (SaaS)
+        env:
+          DEPLOYMENT_MODE: saas
+        run: |
+          cd apps/server
+          pytest -v --cov=. --cov-append --cov-report=xml --cov-report=term-missing
 
       - name: Run bandit security scan
         run: |

--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -891,8 +891,14 @@ def jwt_required(f):
         if not payload:
             return jsonify({"success": False, "error": "Invalid or expired token"}), 401
 
-        g.jwt_user_id = payload["user_id"]
-        g.jwt_role = payload["role"]
+        user = db.session.get(User, payload["user_id"])
+        if not user:
+            return jsonify(
+                {"success": False, "error": "User no longer exists"}
+            ), 401
+
+        g.jwt_user_id = user.id
+        g.jwt_role = user.role
 
         # Get database from X-Database header for mobile clients
         db_name = request.headers.get("X-Database")
@@ -901,7 +907,6 @@ def jwt_required(f):
                 # Special value for all-databases view
                 g.jwt_db_name = "_all_"
             else:
-                user = db.session.get(User, g.jwt_user_id)
                 target_db = Database.query.filter_by(name=db_name).first()
                 if target_db and target_db in user.accessible_databases:
                     g.jwt_db_name = db_name
@@ -933,11 +938,17 @@ def jwt_admin_required(f):
         if not payload:
             return jsonify({"success": False, "error": "Invalid or expired token"}), 401
 
-        if payload["role"] != "admin":
+        user = db.session.get(User, payload["user_id"])
+        if not user:
+            return jsonify(
+                {"success": False, "error": "User no longer exists"}
+            ), 401
+
+        if user.role != "admin":
             return jsonify({"success": False, "error": "Admin access required"}), 403
 
-        g.jwt_user_id = payload["user_id"]
-        g.jwt_role = payload["role"]
+        g.jwt_user_id = user.id
+        g.jwt_role = user.role
         return f(*args, **kwargs)
 
     return decorated_function
@@ -2653,7 +2664,7 @@ def jwt_get_bill(bill_id):
         my_portion = None
         if share.split_type and bill.amount is not None:
             my_portion = share.calculate_portion()
-        owner = db.session.get(User, database.owner_id) if database else None
+        owner = db.session.get(User, share.owner_user_id)
         b_dict["is_shared"] = True
         b_dict["share_info"] = {
             "share_id": share.id,
@@ -7231,6 +7242,18 @@ def twofa_verify():
 # ============ API v2 Admin Endpoints ============
 
 
+def _can_manage_user(actor_user_id, target_user, *, allow_self=False):
+    """Return whether an admin may manage a user in the active deployment mode."""
+    if not is_saas():
+        return True
+    if allow_self and target_user.id == actor_user_id:
+        return True
+    # SaaS administration is intentionally one level deep: an admin manages
+    # the users they directly created, while account owners and other tenants
+    # remain outside that boundary.
+    return target_user.created_by_id == actor_user_id
+
+
 @api_v2_bp.route("/users", methods=["GET"])
 @jwt_admin_required
 def jwt_get_users():
@@ -7354,9 +7377,9 @@ def jwt_update_user(target_user_id):
     """Update user role (admin only)."""
     user = db.get_or_404(User, target_user_id)
     current_user_id = g.jwt_user_id
-    if is_saas() and user.id != current_user_id:
-        if user.created_by_id is not None and user.created_by_id != current_user_id:
-            return jsonify({"success": False, "error": "Access denied"}), 403
+    if not _can_manage_user(current_user_id, user, allow_self=True):
+        return jsonify({"success": False, "error": "Access denied"}), 403
+
     data = request.get_json()
     if "role" in data:
         new_role = data["role"]
@@ -7404,22 +7427,63 @@ def jwt_delete_user(target_user_id):
     """Delete a user (admin only)."""
     if target_user_id == g.jwt_user_id:
         return jsonify({"success": False, "error": "Cannot delete yourself"}), 400
-    user = db.get_or_404(User, target_user_id)
+
+    # Lock the target so a concurrent request cannot add a new dependent row
+    # between cleanup and the final delete.
+    user = db.first_or_404(
+        db.select(User).where(User.id == target_user_id).with_for_update()
+    )
+    current_user_id = g.jwt_user_id
+    current_user = db.session.get(User, current_user_id)
+
+    if not _can_manage_user(current_user_id, user):
+        return jsonify({"success": False, "error": "Access denied"}), 403
+
+    # Never delete only the local record for a subscription that can still be
+    # billed externally. Canceled/expired Stripe records are safe to remove.
+    if (
+        is_saas()
+        and user.subscription
+        and user.subscription.stripe_subscription_id
+        and user.subscription.status not in {"canceled", "incomplete_expired"}
+    ):
+        return jsonify(
+            {
+                "success": False,
+                "error": "Cancel the user's subscription before deleting the user",
+            }
+        ), 409
+
+    owned_databases = Database.query.filter_by(owner_id=target_user_id).all()
+    accessible_databases = list(user.accessible_databases)
+
     if is_saas():
-        current_user_id = g.jwt_user_id
-        current_user = db.session.get(User, current_user_id)
-        if current_user.is_account_owner:
-            pass
-        elif user.created_by_id is not None and user.created_by_id != current_user_id:
-            return jsonify({"success": False, "error": "Access denied"}), 403
+        # Keep managed users and bill groups inside the same tenant. Direct
+        # children are reparented and owned databases transfer to the actor.
+        replacement_owner_id = current_user_id
+        for database in owned_databases:
+            if current_user_id not in {member.id for member in database.users}:
+                database.users.append(current_user)
+    else:
+        replacement_owner_id = None
+        # Ownership fields are unused in self-hosted mode, but deleting the
+        # only user with access must not strand a surviving bill group.
+        candidate_databases = {
+            database.id: database
+            for database in [*owned_databases, *accessible_databases]
+        }
+        for database in candidate_databases.values():
+            remaining_user_ids = {
+                member.id for member in database.users if member.id != target_user_id
+            }
+            if not remaining_user_ids:
+                database.users.append(current_user)
 
     # Several tables reference users.id with no ON DELETE clause, so deleting
     # a user who had ever logged in, sent an invite, or shared a bill would
     # otherwise fail with a foreign key violation. Mirrors the cleanup done
     # in jwt_delete_account, scoped to just this one user.
-    db.session.execute(
-        user_database_access.delete().where(user_database_access.c.user_id == target_user_id)
-    )
+    user.accessible_databases.clear()
     UserInvite.query.filter_by(invited_by_id=target_user_id).delete(synchronize_session=False)
     RefreshToken.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
     UserDevice.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
@@ -7440,13 +7504,12 @@ def jwt_delete_user(target_user_id):
             ShareAuditLog.affected_user_id == target_user_id,
         )
     ).delete(synchronize_session=False)
-    # Deleting this user shouldn't take other users or databases down with it;
-    # just drop the now-dangling reference to them.
+
     User.query.filter_by(created_by_id=target_user_id).update(
-        {"created_by_id": None}, synchronize_session=False
+        {"created_by_id": replacement_owner_id}, synchronize_session=False
     )
     Database.query.filter_by(owner_id=target_user_id).update(
-        {"owner_id": None}, synchronize_session=False
+        {"owner_id": replacement_owner_id}, synchronize_session=False
     )
 
     db.session.delete(user)
@@ -7461,9 +7524,8 @@ def jwt_get_user_databases(target_user_id):
     user = db.get_or_404(User, target_user_id)
     current_user_id = g.jwt_user_id
     # In SaaS mode, only allow viewing databases of users you created (or yourself)
-    if is_saas() and user.id != current_user_id:
-        if user.created_by_id is not None and user.created_by_id != current_user_id:
-            return jsonify({"success": False, "error": "Access denied"}), 403
+    if not _can_manage_user(current_user_id, user, allow_self=True):
+        return jsonify({"success": False, "error": "Access denied"}), 403
     return jsonify(
         {
             "success": True,
@@ -7866,7 +7928,9 @@ def jwt_update_database(database_id):
 @jwt_admin_required
 def jwt_delete_database(database_id):
     """Delete a database/bill group (admin only)."""
-    database = db.get_or_404(Database, database_id)
+    database = db.first_or_404(
+        db.select(Database).where(Database.id == database_id).with_for_update()
+    )
     current_user_id = g.jwt_user_id
 
     if is_saas() and database.owner_id != current_user_id:
@@ -7876,10 +7940,12 @@ def jwt_delete_database(database_id):
     # share_audit_log.bill_id has no ON DELETE clause, so any bill in this
     # group that was ever shared would otherwise fail the whole delete with
     # a foreign key violation (same issue as jwt_delete_bill_permanent).
-    bill_ids = [
-        row[0]
-        for row in db.session.query(Bill.id).filter(Bill.database_id == database.id).all()
-    ]
+    # Lock existing bills as well as the group so concurrent share/audit
+    # writes cannot recreate a dependent row after cleanup.
+    bills = db.session.execute(
+        db.select(Bill).where(Bill.database_id == database.id).with_for_update()
+    ).scalars().all()
+    bill_ids = [bill.id for bill in bills]
     if bill_ids:
         ShareAuditLog.query.filter(ShareAuditLog.bill_id.in_(bill_ids)).delete(
             synchronize_session=False

--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -2943,6 +2943,12 @@ def jwt_delete_bill_permanent(bill_id):
     if conflict:
         return conflict
 
+    # share_audit_log.bill_id has no ON DELETE clause, so a bill that was
+    # ever shared (i.e. has audit history) would otherwise fail this delete
+    # with a foreign key violation. BillShare rows cascade via the Bill.shares
+    # relationship, but the audit log doesn't, so it needs explicit cleanup.
+    ShareAuditLog.query.filter_by(bill_id=bill.id).delete(synchronize_session=False)
+
     db.session.delete(bill)
     response_payload = {
         "success": True,
@@ -7406,6 +7412,43 @@ def jwt_delete_user(target_user_id):
             pass
         elif user.created_by_id is not None and user.created_by_id != current_user_id:
             return jsonify({"success": False, "error": "Access denied"}), 403
+
+    # Several tables reference users.id with no ON DELETE clause, so deleting
+    # a user who had ever logged in, sent an invite, or shared a bill would
+    # otherwise fail with a foreign key violation. Mirrors the cleanup done
+    # in jwt_delete_account, scoped to just this one user.
+    db.session.execute(
+        user_database_access.delete().where(user_database_access.c.user_id == target_user_id)
+    )
+    UserInvite.query.filter_by(invited_by_id=target_user_id).delete(synchronize_session=False)
+    RefreshToken.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    UserDevice.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    Subscription.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    OAuthAccount.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    TwoFAChallenge.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    TwoFAConfig.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    WebAuthnCredential.query.filter_by(user_id=target_user_id).delete(synchronize_session=False)
+    BillShare.query.filter(
+        or_(
+            BillShare.owner_user_id == target_user_id,
+            BillShare.shared_with_user_id == target_user_id,
+        )
+    ).delete(synchronize_session=False)
+    ShareAuditLog.query.filter(
+        or_(
+            ShareAuditLog.actor_user_id == target_user_id,
+            ShareAuditLog.affected_user_id == target_user_id,
+        )
+    ).delete(synchronize_session=False)
+    # Deleting this user shouldn't take other users or databases down with it;
+    # just drop the now-dangling reference to them.
+    User.query.filter_by(created_by_id=target_user_id).update(
+        {"created_by_id": None}, synchronize_session=False
+    )
+    Database.query.filter_by(owner_id=target_user_id).update(
+        {"owner_id": None}, synchronize_session=False
+    )
+
     db.session.delete(user)
     db.session.commit()
     return jsonify({"success": True, "data": {"message": "User deleted"}})
@@ -7828,6 +7871,19 @@ def jwt_delete_database(database_id):
 
     if is_saas() and database.owner_id != current_user_id:
         return jsonify({"success": False, "error": "Access denied"}), 403
+
+    # Bills cascade-delete via the Database.bills relationship, but
+    # share_audit_log.bill_id has no ON DELETE clause, so any bill in this
+    # group that was ever shared would otherwise fail the whole delete with
+    # a foreign key violation (same issue as jwt_delete_bill_permanent).
+    bill_ids = [
+        row[0]
+        for row in db.session.query(Bill.id).filter(Bill.database_id == database.id).all()
+    ]
+    if bill_ids:
+        ShareAuditLog.query.filter(ShareAuditLog.bill_id.in_(bill_ids)).delete(
+            synchronize_session=False
+        )
 
     db.session.delete(database)
     db.session.commit()

--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -26,6 +26,7 @@ os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-for-testing-only'
 os.environ['FLASK_ENV'] = 'testing'
 os.environ['RATE_LIMIT_ENABLED'] = 'false'
 
+import config
 from app import create_app, create_access_token, JWT_SECRET_KEY
 from models import (
     db, User, Database, Bill, Payment,
@@ -90,7 +91,7 @@ def regular_user(app, db_session, admin_user):
         role='user',
         email='user@test.com',
         password_change_required=False,
-        created_by_id=admin_user.id
+        created_by_id=admin_user.id if config.is_saas() else None
     )
     user.set_password('userpassword123')
     db_session.add(user)
@@ -106,7 +107,7 @@ def test_database(app, db_session, admin_user):
         name='testdb',
         display_name='Test Database',
         description='Database for testing',
-        owner_id=admin_user.id
+        owner_id=admin_user.id if config.is_saas() else None
     )
     db_session.add(database)
     db_session.commit()

--- a/apps/server/tests/test_bills.py
+++ b/apps/server/tests/test_bills.py
@@ -10,6 +10,7 @@ import json
 import datetime
 import pytest
 
+import config
 from models import Bill, BillShare, Database, ShareAuditLog, db
 
 
@@ -78,7 +79,9 @@ class TestBillsCRUD:
         never the accepted-share fallback that /payments and /pay already had.
         """
         recipient_db = Database(
-            name='recipientdb2', display_name='Recipient DB', owner_id=regular_user.id
+            name='recipientdb2',
+            display_name='Recipient DB',
+            owner_id=regular_user.id if config.is_saas() else None,
         )
         db_session.add(recipient_db)
         db_session.commit()
@@ -537,7 +540,7 @@ class TestBillSettlements:
             name='recipientdb',
             display_name='Recipient Database',
             description='Database for settlement recipient tests',
-            owner_id=regular_user.id
+            owner_id=regular_user.id if config.is_saas() else None,
         )
         db_session.add(database)
         db_session.commit()
@@ -642,7 +645,7 @@ class TestCashFlowForecast:
             name='recipientdb',
             display_name='Recipient Database',
             description='Database for forecast recipient tests',
-            owner_id=regular_user.id
+            owner_id=regular_user.id if config.is_saas() else None,
         )
         db_session.add(database)
         db_session.commit()
@@ -956,9 +959,16 @@ class TestGetBillSharesSelfHosted:
     "not shared with anyone", regardless of actual share state.
     """
 
+    pytestmark = pytest.mark.skipif(
+        config.is_saas(), reason='requires a self-hosted-mode application process'
+    )
+
     def test_owner_can_list_shares_in_self_hosted_mode(
-        self, client, auth_headers_with_db, db_session, test_bill, admin_user, regular_user
+        self, client, auth_headers_with_db, db_session, test_bill, test_database,
+        admin_user, regular_user
     ):
+        assert test_database.owner_id is None
+
         share = BillShare(
             bill_id=test_bill.id,
             owner_user_id=admin_user.id,

--- a/apps/server/tests/test_bills.py
+++ b/apps/server/tests/test_bills.py
@@ -10,7 +10,7 @@ import json
 import datetime
 import pytest
 
-from models import Bill, BillShare, Database
+from models import Bill, BillShare, Database, ShareAuditLog, db
 
 
 class TestBillsCRUD:
@@ -845,6 +845,56 @@ class TestBillShareCreation:
         after = client.get(f'/api/v2/bills/{test_bill.id}/shares', headers=auth_headers_with_db)
         after_data = json.loads(after.data)['data']
         assert after_data[0]['recipient_paid_date'] is not None
+
+
+class TestPermanentDeleteWithShareHistory:
+    """Regression: share_audit_log.bill_id has no ON DELETE clause, so
+    permanently deleting a bill that had ever been shared (i.e. had any
+    audit log rows) raised a Postgres IntegrityError and surfaced to users
+    as a generic server error, even though the bill's own BillShare rows
+    are cascade-deleted cleanly via the Bill.shares ORM relationship.
+    """
+
+    def test_permanently_deleting_shared_bill_does_not_500(
+        self, client, auth_headers_with_db, db_session, test_bill, admin_user, regular_user
+    ):
+        share = BillShare(
+            bill_id=test_bill.id,
+            owner_user_id=admin_user.id,
+            shared_with_user_id=regular_user.id,
+            shared_with_identifier=regular_user.username,
+            identifier_type='username',
+            status='accepted',
+            accepted_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+
+        ShareAuditLog.log_action(
+            action='created',
+            bill_id=test_bill.id,
+            actor_user_id=admin_user.id,
+            share_id=share.id,
+            affected_user_id=regular_user.id,
+        )
+        ShareAuditLog.log_action(
+            action='accepted',
+            bill_id=test_bill.id,
+            actor_user_id=regular_user.id,
+            share_id=share.id,
+            affected_user_id=admin_user.id,
+        )
+
+        response = client.delete(
+            f'/api/v2/bills/{test_bill.id}/permanent', headers=auth_headers_with_db
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['success'] is True
+
+        assert db.session.get(Bill, test_bill.id) is None
+        assert ShareAuditLog.query.filter_by(bill_id=test_bill.id).count() == 0
 
 
 class TestOneTimeBills:

--- a/apps/server/tests/test_mobile_contracts.py
+++ b/apps/server/tests/test_mobile_contracts.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import yaml
 
+import config
 import app as server_app
 
 from models import (
@@ -310,7 +311,7 @@ def test_bill_move_replays_in_original_database_scope_after_post_state_change(
     destination = Database(
         name="move_destination",
         display_name="Move Destination",
-        owner_id=admin_user.id,
+        owner_id=admin_user.id if config.is_saas() else None,
     )
     db_session.add(destination)
     admin_user.accessible_databases.append(destination)
@@ -402,7 +403,7 @@ def test_deleted_resources_only_replay_in_the_original_database_scope(
     other_database = Database(
         name="wrong_replay_scope",
         display_name="Wrong Replay Scope",
-        owner_id=admin_user.id,
+        owner_id=admin_user.id if config.is_saas() else None,
     )
     payment = Payment(
         bill_id=test_bill.id,
@@ -476,7 +477,7 @@ def test_concurrent_bill_move_retries_replay_after_waiting_for_the_row_lock(
     destination = Database(
         name="concurrent_move_destination",
         display_name="Concurrent Move Destination",
-        owner_id=admin_user.id,
+        owner_id=admin_user.id if config.is_saas() else None,
     )
     db_session.add(destination)
     admin_user.accessible_databases.append(destination)

--- a/apps/server/tests/test_telemetry.py
+++ b/apps/server/tests/test_telemetry.py
@@ -7,11 +7,21 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock
 
 from flask import Flask
+import pytest
 
+import config
 from models import db, TelemetryLog, TelemetrySettings, TelemetrySubmission, User
 from services.scheduler import TaskScheduler
 from services.telemetry import TelemetryCollector
 from services import telemetry_receiver
+
+
+SAAS_ONLY = pytest.mark.skipif(
+    not config.is_saas(), reason='requires a SaaS-mode application process'
+)
+SELF_HOSTED_ONLY = pytest.mark.skipif(
+    config.is_saas(), reason='requires a self-hosted-mode application process'
+)
 
 
 def _response_status(result):
@@ -175,6 +185,7 @@ def test_pending_instance_consent_prevents_network(
     post.assert_not_called()
 
 
+@SELF_HOSTED_ONLY
 def test_collect_metrics_reads_real_database_without_self_host_identifiers(
     app, admin_user, test_database, test_bill, monkeypatch
 ):
@@ -198,6 +209,32 @@ def test_collect_metrics_reads_real_database_without_self_host_identifiers(
     assert metrics["platform"]["database"].startswith("PostgreSQL")
     assert "server_url" not in metrics
     assert "server_ip" not in metrics
+
+
+@SAAS_ONLY
+def test_collect_metrics_includes_saas_deployment_identifiers(
+    app, admin_user, test_database, test_bill, monkeypatch
+):
+    collector = TelemetryCollector()
+    collector.app = app
+    collector.db = db
+    collector.instance_id = str(uuid.uuid4())
+    monkeypatch.setattr(collector, "_restore_instance_id_from_log", Mock())
+    monkeypatch.setattr(
+        collector, "_get_server_url", Mock(return_value="https://app.test")
+    )
+    monkeypatch.setattr(
+        collector, "_get_server_ip", Mock(return_value="203.0.113.10")
+    )
+
+    metrics = collector.collect_metrics()
+
+    assert metrics["deployment_mode"] == "saas"
+    assert metrics["metrics"]["users"]["total"] == 1
+    assert metrics["metrics"]["data"]["databases"] == 1
+    assert metrics["metrics"]["data"]["bills"] == 1
+    assert metrics["server_url"] == "https://app.test"
+    assert metrics["server_ip"] == "203.0.113.10"
 
 
 def test_collect_metrics_counts_users_active_within_thirty_days(
@@ -450,7 +487,7 @@ def test_notice_honors_global_disable(client, admin_auth_headers, monkeypatch):
         "show_notice": False,
         "reason": "globally_disabled",
         "telemetry_enabled": False,
-        "deployment_mode": "self-hosted",
+        "deployment_mode": config.DEPLOYMENT_MODE,
         "consent_state": "pending",
     }
 
@@ -471,7 +508,7 @@ def test_notice_keeps_config_after_owner_choice(
     assert data["opted_out"] is False
     assert data["consent_state"] == "enabled"
     assert data["telemetry_enabled"] is True
-    assert data["deployment_mode"] == "self-hosted"
+    assert data["deployment_mode"] == config.DEPLOYMENT_MODE
 
 
 def test_conservative_instance_migration_prefers_any_owner_opt_out(

--- a/apps/server/tests/test_user_deletion_modes.py
+++ b/apps/server/tests/test_user_deletion_modes.py
@@ -1,0 +1,211 @@
+"""Mode-specific safety contracts for administrative user deletion."""
+
+import datetime
+
+import pytest
+
+import config
+from app import create_access_token
+from models import Database, RefreshToken, Subscription, User, db
+
+
+pytestmark = pytest.mark.skipif(
+    not config.is_saas(), reason='requires a SaaS-mode application process'
+)
+
+
+def _headers_for(user):
+    token = create_access_token(user.id, user.role)
+    return {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
+
+
+def _create_user(db_session, username, *, role='user', creator=None):
+    user = User(
+        username=username,
+        role=role,
+        email=f'{username}@test.com',
+        password_change_required=False,
+        created_by_id=creator.id if creator else None,
+    )
+    user.set_password('pw12345678')
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def test_deleting_direct_subadmin_reparents_children_and_databases(
+    client, db_session, admin_user
+):
+    subadmin = _create_user(
+        db_session, 'transfer-subadmin', role='admin', creator=admin_user
+    )
+    child_admin = _create_user(
+        db_session, 'transfer-child', role='admin', creator=subadmin
+    )
+    database = Database(
+        name='transfer-db',
+        display_name='Transfer DB',
+        owner_id=subadmin.id,
+    )
+    database.users.append(subadmin)
+    db_session.add(database)
+    db_session.commit()
+
+    subadmin_id = subadmin.id
+    child_admin_id = child_admin.id
+    database_id = database.id
+
+    response = client.delete(
+        f'/api/v2/users/{subadmin_id}', headers=_headers_for(admin_user)
+    )
+
+    assert response.status_code == 200
+    db.session.expire_all()
+    assert db.session.get(User, subadmin_id) is None
+    reparented_child = db.session.get(User, child_admin_id)
+    assert reparented_child.created_by_id == admin_user.id
+    assert reparented_child.is_account_owner is False
+    transferred_database = db.session.get(Database, database_id)
+    assert transferred_database.owner_id == admin_user.id
+    assert admin_user.id in {user.id for user in transferred_database.users}
+
+
+def test_account_owner_cannot_delete_another_account_owner_without_cleanup(
+    client, db_session, admin_user
+):
+    other_owner = _create_user(db_session, 'other-owner', role='admin')
+    token = RefreshToken(
+        user_id=other_owner.id,
+        token_hash='1' * 64,
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
+    )
+    db_session.add(token)
+    db_session.commit()
+
+    response = client.delete(
+        f'/api/v2/users/{other_owner.id}', headers=_headers_for(admin_user)
+    )
+
+    assert response.status_code == 403
+    assert db.session.get(User, other_owner.id) is not None
+    assert RefreshToken.query.filter_by(user_id=other_owner.id).count() == 1
+
+
+def test_account_owner_cannot_delete_another_tenants_member(
+    client, db_session, admin_user
+):
+    other_owner = _create_user(db_session, 'tenant-owner', role='admin')
+    other_member = _create_user(
+        db_session, 'tenant-member', creator=other_owner
+    )
+
+    response = client.delete(
+        f'/api/v2/users/{other_member.id}', headers=_headers_for(admin_user)
+    )
+
+    assert response.status_code == 403
+    assert db.session.get(User, other_member.id) is not None
+
+
+def test_subadmin_cannot_delete_parent(client, db_session, admin_user):
+    subadmin = _create_user(
+        db_session, 'parent-guard-subadmin', role='admin', creator=admin_user
+    )
+
+    response = client.delete(
+        f'/api/v2/users/{admin_user.id}', headers=_headers_for(subadmin)
+    )
+
+    assert response.status_code == 403
+    assert db.session.get(User, admin_user.id) is not None
+
+
+def test_subadmin_cannot_delete_sibling(client, db_session, admin_user):
+    subadmin = _create_user(
+        db_session, 'sibling-guard-subadmin', role='admin', creator=admin_user
+    )
+    sibling = _create_user(
+        db_session, 'sibling-guard-user', creator=admin_user
+    )
+
+    response = client.delete(
+        f'/api/v2/users/{sibling.id}', headers=_headers_for(subadmin)
+    )
+
+    assert response.status_code == 403
+    assert db.session.get(User, sibling.id) is not None
+
+
+def test_subadmin_can_delete_direct_child(client, db_session, admin_user):
+    subadmin = _create_user(
+        db_session, 'child-control-subadmin', role='admin', creator=admin_user
+    )
+    child = _create_user(db_session, 'child-control-user', creator=subadmin)
+    child_id = child.id
+
+    response = client.delete(
+        f'/api/v2/users/{child_id}', headers=_headers_for(subadmin)
+    )
+
+    assert response.status_code == 200
+    assert db.session.get(User, child_id) is None
+
+
+def test_external_subscription_blocks_delete_without_partial_cleanup(
+    client, db_session, admin_user, regular_user
+):
+    subscription = Subscription(
+        user_id=regular_user.id,
+        stripe_customer_id='cus_delete_guard',
+        stripe_subscription_id='sub_delete_guard',
+        tier='basic',
+        status='active',
+    )
+    token = RefreshToken(
+        user_id=regular_user.id,
+        token_hash='2' * 64,
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
+    )
+    db_session.add_all([subscription, token])
+    db_session.commit()
+
+    response = client.delete(
+        f'/api/v2/users/{regular_user.id}', headers=_headers_for(admin_user)
+    )
+
+    assert response.status_code == 409
+    assert db.session.get(User, regular_user.id) is not None
+    assert Subscription.query.filter_by(user_id=regular_user.id).count() == 1
+    assert RefreshToken.query.filter_by(user_id=regular_user.id).count() == 1
+
+
+def test_account_owner_cannot_update_or_inspect_another_account_owner(
+    client, db_session, admin_user
+):
+    other_owner = _create_user(db_session, 'endpoint-owner', role='admin')
+    database = Database(
+        name='endpoint-owner-db',
+        display_name='Endpoint Owner DB',
+        owner_id=other_owner.id,
+    )
+    database.users.append(other_owner)
+    db_session.add(database)
+    db_session.commit()
+
+    update_response = client.put(
+        f'/api/v2/users/{other_owner.id}',
+        json={'email': 'stolen@test.com'},
+        headers=_headers_for(admin_user),
+    )
+    databases_response = client.get(
+        f'/api/v2/users/{other_owner.id}/databases',
+        headers=_headers_for(admin_user),
+    )
+
+    assert update_response.status_code == 403
+    assert databases_response.status_code == 403
+    db.session.expire_all()
+    assert db.session.get(User, other_owner.id).email == 'endpoint-owner@test.com'

--- a/apps/server/tests/test_v2_admin_parity.py
+++ b/apps/server/tests/test_v2_admin_parity.py
@@ -222,33 +222,38 @@ class TestV2UserDeletion:
         db_session.add(share)
         db_session.commit()
         db_session.refresh(share)
+        share_id = share.id
         ShareAuditLog.log_action(
-            action='created', bill_id=test_bill.id, actor_user_id=admin_user.id, share_id=share.id,
+            action='created', bill_id=test_bill.id, actor_user_id=admin_user.id, share_id=share_id,
         )
         db_session.commit()
+        admin_user_id = admin_user.id
+        regular_user_id = regular_user.id
 
         response = client.delete(
-            f'/api/v2/users/{admin_user.id}', headers=_headers_for(second_admin)
+            f'/api/v2/users/{admin_user_id}', headers=_headers_for(second_admin)
         )
         assert response.status_code == 200
         assert json.loads(response.data)['success'] is True
 
-        assert db.session.get(User, admin_user.id) is None
+        # The tables below were mutated by bulk queries (synchronize_session=False,
+        # matching jwt_delete_account's existing convention) or by another
+        # session (the Flask request), so previously-loaded ORM references
+        # (admin_user, regular_user, share) are stale/expired. Querying by
+        # the ids captured above avoids SQLAlchemy trying to refresh a
+        # now-gone row and raising ObjectDeletedError.
+        assert db.session.get(User, admin_user_id) is None
         # created_by_id is orphaned rather than blocking the delete, or
         # taking regular_user down with it
-        db_session.refresh(regular_user)
-        assert regular_user.created_by_id is None
-        assert db.session.get(User, regular_user.id) is not None
+        refreshed_regular_user = db.session.get(User, regular_user_id)
+        assert refreshed_regular_user is not None
+        assert refreshed_regular_user.created_by_id is None
         # dependent rows owned by the deleted user are cleaned up rather
         # than left dangling
-        assert RefreshToken.query.filter_by(user_id=admin_user.id).count() == 0
-        assert UserInvite.query.filter_by(invited_by_id=admin_user.id).count() == 0
-        # share.id was bulk-deleted (synchronize_session=False), so the
-        # already-loaded `share` instance is a stale identity-map entry;
-        # db.session.get() would try to refresh it and raise
-        # ObjectDeletedError instead of returning None. Query fresh instead.
-        assert BillShare.query.filter_by(id=share.id).first() is None
-        assert ShareAuditLog.query.filter_by(actor_user_id=admin_user.id).count() == 0
+        assert RefreshToken.query.filter_by(user_id=admin_user_id).count() == 0
+        assert UserInvite.query.filter_by(invited_by_id=admin_user_id).count() == 0
+        assert BillShare.query.filter_by(id=share_id).first() is None
+        assert ShareAuditLog.query.filter_by(actor_user_id=admin_user_id).count() == 0
 
 
 class TestV2DatabaseDeletionWithShareHistory:

--- a/apps/server/tests/test_v2_admin_parity.py
+++ b/apps/server/tests/test_v2_admin_parity.py
@@ -3,11 +3,20 @@ Regression tests for v2 (JWT) admin endpoints that had drifted from their
 v1 (session) counterparts: database description handling, database access
 grant/revoke, SaaS cross-account isolation, and user role-change guards.
 """
+import datetime
 import json
 
 import config
 from app import create_access_token
-from models import Database, User
+from models import (
+    BillShare,
+    Database,
+    RefreshToken,
+    ShareAuditLog,
+    User,
+    UserInvite,
+    db,
+)
 
 
 def _headers_for(user):
@@ -166,3 +175,109 @@ class TestV2UserRoleChangeGuards:
         )
         assert response.status_code == 400
         assert 'account owner' in json.loads(response.data)['error'].lower()
+
+
+class TestV2UserDeletion:
+    """Regression: several foreign keys onto users.id had no ON DELETE
+    clause (created_by_id, refresh_tokens.user_id, user_invites.invited_by_id,
+    bill_shares.owner_user_id, share_audit_log.actor_user_id), so deleting a
+    user who had ever logged in, invited someone, or shared a bill raised a
+    Postgres IntegrityError, surfaced to admins as a generic server error.
+    jwt_delete_user now cleans up the same tables jwt_delete_account already
+    did, scoped to just the one user being removed.
+    """
+
+    def test_deleting_user_with_related_history_does_not_500(
+        self, client, db_session, admin_user, regular_user, test_bill
+    ):
+        second_admin = User(
+            username='seconddeleter',
+            role='admin',
+            email='seconddeleter@test.com',
+        )
+        second_admin.set_password('pw12345678')
+        db_session.add(second_admin)
+        db_session.commit()
+
+        # admin_user created regular_user (via the fixture) -> created_by_id
+        db_session.add(RefreshToken(
+            user_id=admin_user.id,
+            token_hash='a' * 64,
+            expires_at=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1),
+        ))
+        db_session.add(UserInvite(
+            email='invitee@test.com',
+            token='b' * 64,
+            invited_by_id=admin_user.id,
+            expires_at=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=7),
+        ))
+        share = BillShare(
+            bill_id=test_bill.id,
+            owner_user_id=admin_user.id,
+            shared_with_user_id=regular_user.id,
+            shared_with_identifier=regular_user.username,
+            identifier_type='username',
+            status='accepted',
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+        ShareAuditLog.log_action(
+            action='created', bill_id=test_bill.id, actor_user_id=admin_user.id, share_id=share.id,
+        )
+        db_session.commit()
+
+        response = client.delete(
+            f'/api/v2/users/{admin_user.id}', headers=_headers_for(second_admin)
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data)['success'] is True
+
+        assert db.session.get(User, admin_user.id) is None
+        # created_by_id is orphaned rather than blocking the delete, or
+        # taking regular_user down with it
+        db_session.refresh(regular_user)
+        assert regular_user.created_by_id is None
+        assert db.session.get(User, regular_user.id) is not None
+        # dependent rows owned by the deleted user are cleaned up rather
+        # than left dangling
+        assert RefreshToken.query.filter_by(user_id=admin_user.id).count() == 0
+        assert UserInvite.query.filter_by(invited_by_id=admin_user.id).count() == 0
+        assert db.session.get(BillShare, share.id) is None
+        assert ShareAuditLog.query.filter_by(actor_user_id=admin_user.id).count() == 0
+
+
+class TestV2DatabaseDeletionWithShareHistory:
+    """Regression: deleting a bill group cascade-deletes its bills via the
+    Database.bills relationship, but share_audit_log.bill_id has no ON
+    DELETE clause, so a group containing any bill that was ever shared
+    would fail the whole delete with a foreign key violation.
+    """
+
+    def test_deleting_database_with_shared_bill_does_not_500(
+        self, client, admin_auth_headers, db_session, admin_user, regular_user, test_bill, test_database
+    ):
+        share = BillShare(
+            bill_id=test_bill.id,
+            owner_user_id=admin_user.id,
+            shared_with_user_id=regular_user.id,
+            shared_with_identifier=regular_user.username,
+            identifier_type='username',
+            status='accepted',
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+        ShareAuditLog.log_action(
+            action='created', bill_id=test_bill.id, actor_user_id=admin_user.id, share_id=share.id,
+        )
+        db_session.commit()
+
+        response = client.delete(
+            f'/api/v2/databases/{test_database.id}', headers=admin_auth_headers
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data)['success'] is True
+
+        assert db.session.get(Database, test_database.id) is None
+        assert ShareAuditLog.query.filter_by(bill_id=test_bill.id).count() == 0

--- a/apps/server/tests/test_v2_admin_parity.py
+++ b/apps/server/tests/test_v2_admin_parity.py
@@ -6,15 +6,25 @@ grant/revoke, SaaS cross-account isolation, and user role-change guards.
 import datetime
 import json
 
+import pytest
 import config
+from sqlalchemy import event
 from app import create_access_token
 from models import (
     BillShare,
+    ClientMutation,
     Database,
+    OAuthAccount,
     RefreshToken,
     ShareAuditLog,
+    Subscription,
+    TelemetrySettings,
+    TwoFAChallenge,
+    TwoFAConfig,
     User,
+    UserDevice,
     UserInvite,
+    WebAuthnCredential,
     db,
 )
 
@@ -22,6 +32,14 @@ from models import (
 def _headers_for(user):
     token = create_access_token(user.id, user.role)
     return {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
+
+
+SAAS_ONLY = pytest.mark.skipif(
+    not config.is_saas(), reason='requires a SaaS-mode application process'
+)
+SELF_HOSTED_ONLY = pytest.mark.skipif(
+    config.is_saas(), reason='requires a self-hosted-mode application process'
+)
 
 
 class TestV2DatabaseDescription:
@@ -90,11 +108,11 @@ class TestV2AccessGrantRevokeIdempotency:
 
 
 class TestV2SaaSCrossAccountGrantDenial:
-    def test_cannot_grant_access_to_user_outside_account(
-        self, client, db_session, admin_user, monkeypatch
-    ):
-        monkeypatch.setattr(config, 'DEPLOYMENT_MODE', 'saas')
+    pytestmark = SAAS_ONLY
 
+    def test_cannot_grant_access_to_user_outside_account(
+        self, client, db_session, admin_user
+    ):
         database = Database(name='ownerdb', display_name='Owner DB', owner_id=admin_user.id)
         db_session.add(database)
         db_session.commit()
@@ -122,9 +140,7 @@ class TestV2SaaSCrossAccountGrantDenial:
         assert response.status_code == 403
         assert json.loads(response.data)['success'] is False
 
-    def test_can_grant_access_to_own_created_user(self, client, db_session, admin_user, regular_user, monkeypatch):
-        monkeypatch.setattr(config, 'DEPLOYMENT_MODE', 'saas')
-
+    def test_can_grant_access_to_own_created_user(self, client, db_session, admin_user, regular_user):
         database = Database(name='ownerdb2', display_name='Owner DB 2', owner_id=admin_user.id)
         db_session.add(database)
         db_session.commit()
@@ -155,9 +171,8 @@ class TestV2UserRoleChangeGuards:
         )
         assert response.status_code == 400
 
-    def test_cannot_demote_account_owner_in_saas_mode(self, client, db_session, admin_user, monkeypatch):
-        monkeypatch.setattr(config, 'DEPLOYMENT_MODE', 'saas')
-
+    @SAAS_ONLY
+    def test_subadmin_cannot_update_account_owner(self, client, db_session, admin_user):
         sub_admin = User(
             username='subadmin',
             role='admin',
@@ -173,8 +188,8 @@ class TestV2UserRoleChangeGuards:
             json={'role': 'user'},
             headers=_headers_for(sub_admin),
         )
-        assert response.status_code == 400
-        assert 'account owner' in json.loads(response.data)['error'].lower()
+        assert response.status_code == 403
+        assert 'access denied' in json.loads(response.data)['error'].lower()
 
 
 class TestV2UserDeletion:
@@ -187,8 +202,16 @@ class TestV2UserDeletion:
     did, scoped to just the one user being removed.
     """
 
+    pytestmark = SELF_HOSTED_ONLY
+
     def test_deleting_user_with_related_history_does_not_500(
-        self, client, db_session, admin_user, regular_user, test_bill
+        self,
+        client,
+        db_session,
+        admin_user,
+        regular_user,
+        test_bill,
+        test_database,
     ):
         second_admin = User(
             username='seconddeleter',
@@ -197,6 +220,12 @@ class TestV2UserDeletion:
         )
         second_admin.set_password('pw12345678')
         db_session.add(second_admin)
+        db_session.commit()
+
+        # Exercise legacy/backfilled tenancy references even though new
+        # self-hosted users and databases normally leave them unset.
+        regular_user.created_by_id = admin_user.id
+        test_database.owner_id = admin_user.id
         db_session.commit()
 
         # admin_user created regular_user (via the fixture) -> created_by_id
@@ -211,6 +240,52 @@ class TestV2UserDeletion:
             invited_by_id=admin_user.id,
             expires_at=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=7),
         ))
+        db_session.add_all([
+            UserDevice(
+                user_id=admin_user.id,
+                device_id='delete-device',
+                platform='ios',
+            ),
+            Subscription(
+                user_id=admin_user.id,
+                status='canceled',
+            ),
+            OAuthAccount(
+                user_id=admin_user.id,
+                provider='oidc',
+                provider_user_id='delete-provider-user',
+            ),
+            TwoFAConfig(
+                user_id=admin_user.id,
+                email_otp_enabled=True,
+            ),
+            TwoFAChallenge(
+                user_id=admin_user.id,
+                token_hash='c' * 64,
+                challenge_type='email_otp',
+                expires_at=datetime.datetime.now(datetime.timezone.utc)
+                + datetime.timedelta(minutes=5),
+            ),
+            WebAuthnCredential(
+                user_id=admin_user.id,
+                credential_id='delete-credential',
+                public_key='delete-public-key',
+            ),
+            ClientMutation(
+                user_id=admin_user.id,
+                database_id=test_database.id,
+                client_mutation_id='00000000-0000-0000-0000-000000000001',
+                operation='delete-user-fixture',
+                request_hash='d' * 64,
+                response_status=200,
+                response_body='{}',
+            ),
+            TelemetrySettings(
+                id=1,
+                state='enabled',
+                decided_by_user_id=admin_user.id,
+            ),
+        ])
         share = BillShare(
             bill_id=test_bill.id,
             owner_user_id=admin_user.id,
@@ -229,9 +304,12 @@ class TestV2UserDeletion:
         db_session.commit()
         admin_user_id = admin_user.id
         regular_user_id = regular_user.id
+        second_admin_id = second_admin.id
+        database_id = test_database.id
+        deleted_user_headers = _headers_for(admin_user)
 
         response = client.delete(
-            f'/api/v2/users/{admin_user_id}', headers=_headers_for(second_admin)
+            f'/api/v2/users/{admin_user_id}', headers=_headers_for(second_admin),
         )
         assert response.status_code == 200
         assert json.loads(response.data)['success'] is True
@@ -248,10 +326,26 @@ class TestV2UserDeletion:
         refreshed_regular_user = db.session.get(User, regular_user_id)
         assert refreshed_regular_user is not None
         assert refreshed_regular_user.created_by_id is None
+        refreshed_database = db.session.get(Database, database_id)
+        assert refreshed_database is not None
+        assert refreshed_database.owner_id is None
+        assert second_admin_id in {u.id for u in refreshed_database.users}
+        assert client.get('/api/v2/me', headers=deleted_user_headers).status_code == 401
+        assert client.get('/api/v2/users', headers=deleted_user_headers).status_code == 401
         # dependent rows owned by the deleted user are cleaned up rather
         # than left dangling
         assert RefreshToken.query.filter_by(user_id=admin_user_id).count() == 0
         assert UserInvite.query.filter_by(invited_by_id=admin_user_id).count() == 0
+        assert UserDevice.query.filter_by(user_id=admin_user_id).count() == 0
+        assert Subscription.query.filter_by(user_id=admin_user_id).count() == 0
+        assert OAuthAccount.query.filter_by(user_id=admin_user_id).count() == 0
+        assert TwoFAConfig.query.filter_by(user_id=admin_user_id).count() == 0
+        assert TwoFAChallenge.query.filter_by(user_id=admin_user_id).count() == 0
+        assert WebAuthnCredential.query.filter_by(user_id=admin_user_id).count() == 0
+        assert ClientMutation.query.filter_by(user_id=admin_user_id).count() == 0
+        telemetry_settings = db.session.get(TelemetrySettings, 1)
+        assert telemetry_settings is not None
+        assert telemetry_settings.decided_by_user_id is None
         assert BillShare.query.filter_by(id=share_id).first() is None
         assert ShareAuditLog.query.filter_by(actor_user_id=admin_user_id).count() == 0
 
@@ -282,11 +376,27 @@ class TestV2DatabaseDeletionWithShareHistory:
         )
         db_session.commit()
 
-        response = client.delete(
-            f'/api/v2/databases/{test_database.id}', headers=admin_auth_headers
-        )
+        statements = []
+
+        def capture_statement(
+            connection, cursor, statement, parameters, context, executemany
+        ):
+            statements.append(statement)
+
+        event.listen(db.engine, 'before_cursor_execute', capture_statement)
+        try:
+            response = client.delete(
+                f'/api/v2/databases/{test_database.id}', headers=admin_auth_headers
+            )
+        finally:
+            event.remove(db.engine, 'before_cursor_execute', capture_statement)
+
         assert response.status_code == 200
         assert json.loads(response.data)['success'] is True
+        assert any(
+            'FROM BILLS' in statement.upper() and 'FOR UPDATE' in statement.upper()
+            for statement in statements
+        )
 
         assert db.session.get(Database, test_database.id) is None
         assert ShareAuditLog.query.filter_by(bill_id=test_bill.id).count() == 0

--- a/apps/server/tests/test_v2_admin_parity.py
+++ b/apps/server/tests/test_v2_admin_parity.py
@@ -243,7 +243,11 @@ class TestV2UserDeletion:
         # than left dangling
         assert RefreshToken.query.filter_by(user_id=admin_user.id).count() == 0
         assert UserInvite.query.filter_by(invited_by_id=admin_user.id).count() == 0
-        assert db.session.get(BillShare, share.id) is None
+        # share.id was bulk-deleted (synchronize_session=False), so the
+        # already-loaded `share` instance is a stale identity-map entry;
+        # db.session.get() would try to refresh it and raise
+        # ObjectDeletedError instead of returning None. Query fresh instead.
+        assert BillShare.query.filter_by(id=share.id).first() is None
         assert ShareAuditLog.query.filter_by(actor_user_id=admin_user.id).count() == 0
 
 

--- a/scripts/test-backend.sh
+++ b/scripts/test-backend.sh
@@ -58,11 +58,25 @@ run_tests() {
     exit 1
   fi
 
-  (
-    cd "${ROOT_DIR}/apps/server"
-    source "${VENV_DIR}/bin/activate"
-    DATABASE_URL="${DATABASE_URL}" pytest tests -v -s --maxfail=1
-  )
+  local modes="${BACKEND_TEST_MODES:-${DEPLOYMENT_MODE:-self-hosted saas}}"
+  local mode
+
+  for mode in ${modes}; do
+    case "${mode}" in
+      self-hosted|saas) ;;
+      *)
+        printf 'Unsupported backend test deployment mode: %s\n' "${mode}" >&2
+        exit 1
+        ;;
+    esac
+
+    printf 'Running backend tests in %s mode\n' "${mode}"
+    (
+      cd "${ROOT_DIR}/apps/server"
+      source "${VENV_DIR}/bin/activate"
+      DATABASE_URL="${DATABASE_URL}" DEPLOYMENT_MODE="${mode}" pytest tests -v -s --maxfail=1
+    )
+  done
 }
 
 main() {


### PR DESCRIPTION
## Summary

- Carries forward the FK cleanup from #74 for permanent bill, user, and bill-group deletion.
- Enforces direct-manager SaaS boundaries across user update, delete, and database-inspection endpoints.
- Reparents managed users and transfers owned databases plus access instead of creating SaaS account owners or ownerless data.
- Preserves otherwise stranded bill-group access when deleting a user in self-hosted mode.
- Blocks deletion while an externally managed Stripe subscription may still bill.
- Invalidates access JWTs for deleted users and derives current roles from the database.
- Locks deletion targets and child bills to close concurrent dependent-row races.
- Makes shared fixtures and direct test data match real self-hosted versus SaaS ownership.
- Runs the complete backend suite in separate self-hosted and SaaS processes in CI and the local test script.
- Fixes the shared-bill owner name lookup that the faithful self-hosted suite exposed.

## Validation

- Self-hosted backend: 181 passed, 12 intentionally skipped
- SaaS backend: 190 passed, 3 intentionally skipped
- Bandit: passed
- pip-audit: no known vulnerabilities
- Python compile, shell syntax, workflow YAML, and diff checks: passed

## Context

This supersedes the now-closed #74 while retaining its original FK fixes.

A separate follow-up should harden the pre-existing /api/v2/account path for nested managed users and external subscription cancellation; this PR does not expand account-erasure semantics.