### PR TITLE
Harden complete account erasure

### DIFF
--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -2231,27 +2231,94 @@ def jwt_delete_account():
     elif confirm is not True:
         return jsonify({"success": False, "error": "Confirmation required"}), 400
 
-    account_users = User.query.filter(
-        or_(User.id == current_user.id, User.created_by_id == current_user.id)
-    ).all()
-    account_user_ids = [u.id for u in account_users]
+    # Lock the owner first, then discover and lock every generation of managed
+    # users. Locking each parent before querying its children prevents a new
+    # descendant from being inserted between discovery and deletion.
+    current_user = db.session.execute(
+        db.select(User).where(User.id == current_user.id).with_for_update()
+    ).scalar_one()
+    account_users = [current_user]
+    account_user_depths = {current_user.id: 0}
+    frontier_ids = [current_user.id]
 
-    owned_databases = Database.query.filter_by(owner_id=current_user.id).all()
+    while frontier_ids:
+        children = db.session.execute(
+            db.select(User)
+            .where(User.created_by_id.in_(frontier_ids))
+            .order_by(User.id)
+            .with_for_update()
+        ).scalars().all()
+        next_frontier = []
+        for child in children:
+            if child.id in account_user_depths:
+                continue
+            account_user_depths[child.id] = account_user_depths[child.created_by_id] + 1
+            account_users.append(child)
+            next_frontier.append(child.id)
+        frontier_ids = next_frontier
+
+    account_user_ids = list(account_user_depths)
+
+    # Databases belong to the whole managed-user tree, not only the root
+    # account owner. Locking both databases and bills closes the same
+    # concurrent dependent-row race handled by the individual delete routes.
+    owned_databases = db.session.execute(
+        db.select(Database)
+        .where(Database.owner_id.in_(account_user_ids))
+        .order_by(Database.id)
+        .with_for_update()
+    ).scalars().all()
     owned_database_ids = [d.id for d in owned_databases]
 
     bill_ids = []
     if owned_database_ids:
         bill_ids = [
-            row[0]
-            for row in db.session.query(Bill.id)
-            .filter(Bill.database_id.in_(owned_database_ids))
-            .all()
+            bill.id
+            for bill in db.session.execute(
+                db.select(Bill)
+                .where(Bill.database_id.in_(owned_database_ids))
+                .order_by(Bill.id)
+                .with_for_update()
+            ).scalars().all()
         ]
+
+    subscriptions = db.session.execute(
+        db.select(Subscription)
+        .where(Subscription.user_id.in_(account_user_ids))
+        .order_by(Subscription.id)
+        .with_for_update()
+    ).scalars().all()
+
+    # Account erasure is the final opportunity to stop external billing.
+    # Cancel every live Stripe subscription before making local destructive
+    # changes. If Stripe cannot confirm cancellation, preserve the local data
+    # so the request can be retried safely.
+    if is_saas():
+        for subscription in subscriptions:
+            if (
+                not subscription.stripe_subscription_id
+                or subscription.status in {"canceled", "incomplete_expired"}
+            ):
+                continue
+            result = cancel_subscription(
+                subscription.stripe_subscription_id, at_period_end=False
+            )
+            if result.get("error"):
+                db.session.rollback()
+                return jsonify(
+                    {
+                        "success": False,
+                        "error": "Unable to cancel subscription; account was not deleted",
+                    }
+                ), 502
 
     if account_user_ids:
         db.session.execute(
             user_database_access.delete().where(
-                user_database_access.c.user_id.in_(account_user_ids)
+                or_(
+                    user_database_access.c.user_id.in_(account_user_ids),
+                    user_database_access.c.database_id.in_(owned_database_ids),
+                )
             )
         )
 
@@ -2279,6 +2346,15 @@ def jwt_delete_account():
         WebAuthnCredential.query.filter(
             WebAuthnCredential.user_id.in_(account_user_ids)
         ).delete(synchronize_session=False)
+        TelemetrySettings.query.filter(
+            TelemetrySettings.decided_by_user_id.in_(account_user_ids)
+        ).update({"decided_by_user_id": None}, synchronize_session=False)
+        ClientMutation.query.filter(
+            or_(
+                ClientMutation.user_id.in_(account_user_ids),
+                ClientMutation.database_id.in_(owned_database_ids),
+            )
+        ).delete(synchronize_session=False)
 
         BillShare.query.filter(
             or_(
@@ -2302,18 +2378,15 @@ def jwt_delete_account():
             synchronize_session=False
         )
 
-    if owned_database_ids:
-        db.session.execute(
-            user_database_access.delete().where(
-                user_database_access.c.database_id.in_(owned_database_ids)
-            )
-        )
-
     for database in owned_databases:
         db.session.delete(database)
 
+    # created_by_id has no database cascade, so children must be removed before
+    # their parents. Depth also makes the ordering deterministic for retries.
     for user in sorted(
-        account_users, key=lambda u: 1 if u.id == current_user.id else 0
+        account_users,
+        key=lambda user: (account_user_depths[user.id], user.id),
+        reverse=True,
     ):
         db.session.delete(user)
 

--- a/apps/server/services/stripe_service.py
+++ b/apps/server/services/stripe_service.py
@@ -262,6 +262,24 @@ def cancel_subscription(subscription_id: str, at_period_end: bool = True) -> dic
             'status': subscription.status,
             'cancel_at_period_end': getattr(subscription, 'cancel_at_period_end', None)
         }
+    except stripe.error.InvalidRequestError as e:
+        # Immediate cancellation removes the subscription object from Stripe.
+        # A retried account-erasure request can therefore see resource_missing
+        # after a prior attempt canceled this subscription but failed on a
+        # later one. Treat absence as the desired idempotent end state.
+        if getattr(e, 'code', None) == 'resource_missing':
+            logger.info(
+                "Stripe subscription %s is already absent during cancellation",
+                subscription_id,
+            )
+            return {
+                'id': subscription_id,
+                'status': 'canceled',
+                'cancel_at_period_end': None,
+                'already_absent': True,
+            }
+        logger.error(f"Stripe cancel error: {e}")
+        return {'error': 'Unable to cancel subscription. Please try again.'}
     except stripe.error.StripeError as e:
         logger.error(f"Stripe cancel error: {e}")
         return {'error': 'Unable to cancel subscription. Please try again.'}

--- a/apps/server/tests/test_account_deletion.py
+++ b/apps/server/tests/test_account_deletion.py
@@ -1,0 +1,243 @@
+"""Safety contracts for full SaaS account erasure."""
+
+from unittest.mock import Mock
+
+import pytest
+
+import config
+from app import create_access_token
+from models import Bill, Database, Subscription, User, db
+
+
+pytestmark = pytest.mark.skipif(
+    not config.is_saas(), reason="requires a SaaS-mode application process"
+)
+
+
+def _headers_for(user):
+    token = create_access_token(user.id, user.role)
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+def _create_user(db_session, username, *, role="user", creator=None):
+    user = User(
+        username=username,
+        role=role,
+        email=f"{username}@test.com",
+        password_change_required=False,
+        created_by_id=creator.id if creator else None,
+    )
+    user.set_password("pw12345678")
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def test_delete_account_erases_nested_users_and_their_owned_databases(
+    client, db_session, admin_user
+):
+    subadmin = _create_user(
+        db_session, "erasure-subadmin", role="admin", creator=admin_user
+    )
+    nested_admin = _create_user(
+        db_session, "erasure-nested-admin", role="admin", creator=subadmin
+    )
+    nested_user = _create_user(
+        db_session, "erasure-nested-user", creator=nested_admin
+    )
+
+    nested_database = Database(
+        name="erasure-nested-db",
+        display_name="Nested account data",
+        owner_id=nested_admin.id,
+    )
+    nested_database.users.extend([nested_admin, nested_user])
+    nested_bill = Bill(
+        database=nested_database,
+        name="Nested bill",
+        amount=42.00,
+        frequency="monthly",
+        due_date="2026-08-01",
+        type="expense",
+    )
+    db_session.add_all([nested_database, nested_bill])
+    db_session.commit()
+
+    other_owner = _create_user(db_session, "erasure-other-owner", role="admin")
+    unrelated_database = Database(
+        name="erasure-unrelated-db",
+        display_name="Another tenant's data",
+        owner_id=other_owner.id,
+    )
+    unrelated_database.users.extend([other_owner, nested_user])
+    db_session.add(unrelated_database)
+    db_session.commit()
+
+    account_user_ids = {
+        admin_user.id,
+        subadmin.id,
+        nested_admin.id,
+        nested_user.id,
+    }
+    nested_database_id = nested_database.id
+    nested_bill_id = nested_bill.id
+    other_owner_id = other_owner.id
+    unrelated_database_id = unrelated_database.id
+
+    response = client.delete(
+        "/api/v2/account",
+        json={"password": "testpassword123"},
+        headers=_headers_for(admin_user),
+    )
+
+    assert response.status_code == 200
+    db.session.expire_all()
+    assert all(db.session.get(User, user_id) is None for user_id in account_user_ids)
+    assert db.session.get(Database, nested_database_id) is None
+    assert db.session.get(Bill, nested_bill_id) is None
+
+    unrelated_owner = db.session.get(User, other_owner_id)
+    unrelated = db.session.get(Database, unrelated_database_id)
+    assert unrelated_owner is not None
+    assert unrelated is not None
+    assert unrelated.owner_id == other_owner_id
+    assert {user.id for user in unrelated.users} == {other_owner_id}
+
+
+def test_delete_account_cancels_external_subscriptions_immediately(
+    client, db_session, admin_user, monkeypatch
+):
+    managed_user = _create_user(
+        db_session, "erasure-subscriber", creator=admin_user
+    )
+    subscriptions = [
+        Subscription(
+            user_id=admin_user.id,
+            stripe_customer_id="cus_erasure_owner",
+            stripe_subscription_id="sub_erasure_owner",
+            tier="plus",
+            status="active",
+        ),
+        Subscription(
+            user_id=managed_user.id,
+            stripe_customer_id="cus_erasure_member",
+            stripe_subscription_id="sub_erasure_member",
+            tier="basic",
+            status="trialing",
+        ),
+    ]
+    db_session.add_all(subscriptions)
+    db_session.commit()
+    owner_id = admin_user.id
+    managed_user_id = managed_user.id
+
+    cancel = Mock(side_effect=lambda subscription_id, at_period_end: {
+        "id": subscription_id,
+        "status": "canceled",
+    })
+    monkeypatch.setattr("app.cancel_subscription", cancel)
+
+    response = client.delete(
+        "/api/v2/account",
+        json={"password": "testpassword123"},
+        headers=_headers_for(admin_user),
+    )
+
+    assert response.status_code == 200
+    assert cancel.call_count == 2
+    assert {
+        (call.args[0], call.kwargs["at_period_end"])
+        for call in cancel.call_args_list
+    } == {
+        ("sub_erasure_owner", False),
+        ("sub_erasure_member", False),
+    }
+    assert db.session.get(User, owner_id) is None
+    assert db.session.get(User, managed_user_id) is None
+    assert Subscription.query.count() == 0
+
+
+def test_stripe_cancellation_failure_preserves_local_account_data(
+    client, db_session, admin_user, monkeypatch
+):
+    subscription = Subscription(
+        user_id=admin_user.id,
+        stripe_customer_id="cus_erasure_failure",
+        stripe_subscription_id="sub_erasure_failure",
+        tier="plus",
+        status="active",
+    )
+    database = Database(
+        name="erasure-failure-db",
+        display_name="Must survive failed cancellation",
+        owner_id=admin_user.id,
+    )
+    database.users.append(admin_user)
+    db_session.add_all([subscription, database])
+    db_session.commit()
+    user_id = admin_user.id
+    database_id = database.id
+
+    cancel = Mock(return_value={"error": "Stripe unavailable"})
+    monkeypatch.setattr("app.cancel_subscription", cancel)
+
+    response = client.delete(
+        "/api/v2/account",
+        json={"password": "testpassword123"},
+        headers=_headers_for(admin_user),
+    )
+
+    assert response.status_code == 502
+    assert response.get_json() == {
+        "success": False,
+        "error": "Unable to cancel subscription; account was not deleted",
+    }
+    cancel.assert_called_once_with("sub_erasure_failure", at_period_end=False)
+    db.session.expire_all()
+    assert db.session.get(User, user_id) is not None
+    assert db.session.get(Database, database_id) is not None
+    assert Subscription.query.filter_by(user_id=user_id).count() == 1
+
+
+def test_invalid_password_does_not_cancel_or_delete(
+    client, db_session, admin_user, monkeypatch
+):
+    subscription = Subscription(
+        user_id=admin_user.id,
+        stripe_subscription_id="sub_wrong_password",
+        status="active",
+    )
+    db_session.add(subscription)
+    db_session.commit()
+    owner_id = admin_user.id
+
+    cancel = Mock()
+    monkeypatch.setattr("app.cancel_subscription", cancel)
+
+    response = client.delete(
+        "/api/v2/account",
+        json={"password": "definitely-wrong"},
+        headers=_headers_for(admin_user),
+    )
+
+    assert response.status_code == 401
+    cancel.assert_not_called()
+    assert db.session.get(User, owner_id) is not None
+    assert Subscription.query.filter_by(user_id=owner_id).count() == 1
+
+
+def test_managed_user_cannot_delete_the_account(client, db_session, admin_user):
+    managed_user = _create_user(
+        db_session, "erasure-non-owner", creator=admin_user
+    )
+
+    response = client.delete(
+        "/api/v2/account",
+        json={"password": "pw12345678"},
+        headers=_headers_for(managed_user),
+    )
+
+    assert response.status_code == 403
+    assert db.session.get(User, admin_user.id) is not None
+    assert db.session.get(User, managed_user.id) is not None

--- a/apps/server/tests/test_stripe_service.py
+++ b/apps/server/tests/test_stripe_service.py
@@ -1,0 +1,32 @@
+"""Focused contracts for Stripe service retry safety."""
+
+import stripe
+
+from services import stripe_service
+
+
+def test_immediate_cancel_treats_missing_subscription_as_already_canceled(
+    monkeypatch,
+):
+    monkeypatch.setattr(stripe_service, "STRIPE_AVAILABLE", True)
+    monkeypatch.setattr(stripe_service, "STRIPE_SECRET_KEY", "sk_test_erasure")
+
+    def missing_subscription(_subscription_id):
+        raise stripe.error.InvalidRequestError(
+            "No such subscription",
+            "id",
+            code="resource_missing",
+        )
+
+    monkeypatch.setattr(stripe_service.stripe.Subscription, "delete", missing_subscription)
+
+    result = stripe_service.cancel_subscription(
+        "sub_already_removed", at_period_end=False
+    )
+
+    assert result == {
+        "id": "sub_already_removed",
+        "status": "canceled",
+        "cancel_at_period_end": None,
+        "already_absent": True,
+    }


### PR DESCRIPTION
## Summary

- recursively discovers and deletes the full managed-user tree instead of only direct children
- deletes bill groups owned anywhere in that tree while preserving unrelated tenant data
- locks users, bill groups, bills, and subscriptions during discovery to close dependent-row races
- immediately cancels every live Stripe subscription before local erasure
- preserves all local data and returns 502 when Stripe cannot confirm cancellation
- makes immediate Stripe cancellation idempotent when a retry finds a subscription already absent
- explicitly cleans up telemetry and offline-mutation references

## Regression coverage

- nested sub-admins, nested users, and nested-owned bill groups are fully erased
- cross-tenant bill groups survive and lose only the deleted account access
- owner and managed-user subscriptions are canceled immediately
- Stripe failure leaves the local account intact
- invalid-password and non-owner controls remain enforced
- missing Stripe resources are treated as the already-canceled retry state

## Validation

- self-hosted backend: 182 passed, 17 intentionally skipped
- SaaS backend: 196 passed, 3 intentionally skipped
- focused account/Stripe tests: passed in both deployment modes
- Python compileall: passed
- Bandit: no issues identified
- pip-audit: no known vulnerabilities
- git diff --check: passed

## Context

Follow-up to #75 and the account-erasure risk identified while replacing #74.
