### PR TITLE
Normalize destructive foreign-key contracts

### DIFF
--- a/apps/server/db_migrations.py
+++ b/apps/server/db_migrations.py
@@ -911,6 +911,91 @@ def migrate_20260715_04_add_user_last_login_at(db):
     db.session.commit()
 
 
+def _replace_fk_delete_action(
+    db,
+    *,
+    table_name,
+    column_name,
+    referred_table,
+    referred_column,
+    ondelete,
+):
+    """Replace one existing FK while preserving its database-assigned name."""
+    matching_foreign_keys = [
+        foreign_key
+        for foreign_key in inspect(db.engine).get_foreign_keys(table_name)
+        if foreign_key['constrained_columns'] == [column_name]
+        and foreign_key['referred_table'] == referred_table
+        and foreign_key['referred_columns'] == [referred_column]
+    ]
+    if len(matching_foreign_keys) != 1:
+        raise RuntimeError(
+            f"Expected one foreign key for {table_name}.{column_name}, "
+            f"found {len(matching_foreign_keys)}"
+        )
+
+    foreign_key = matching_foreign_keys[0]
+    current_action = (
+        foreign_key.get('options', {}).get('ondelete') or 'NO ACTION'
+    )
+    if current_action.upper() == ondelete:
+        logger.info(
+            "%s.%s already uses ON DELETE %s",
+            table_name,
+            column_name,
+            ondelete,
+        )
+        return
+
+    if db.engine.dialect.name != 'postgresql':
+        raise RuntimeError(
+            f"Cannot replace {table_name}.{column_name} foreign key on "
+            f"{db.engine.dialect.name}"
+        )
+
+    constraint_name = foreign_key.get('name')
+    if not constraint_name:
+        raise RuntimeError(f"Foreign key for {table_name}.{column_name} has no name")
+
+    quote = db.engine.dialect.identifier_preparer.quote
+    db.session.execute(text(f'''
+        ALTER TABLE {quote(table_name)}
+        DROP CONSTRAINT {quote(constraint_name)},
+        ADD CONSTRAINT {quote(constraint_name)}
+            FOREIGN KEY ({quote(column_name)})
+            REFERENCES {quote(referred_table)} ({quote(referred_column)})
+            ON DELETE {ondelete}
+    '''))
+    logger.info(
+        "Changed %s.%s to ON DELETE %s",
+        table_name,
+        column_name,
+        ondelete,
+    )
+
+
+def migrate_20260716_01_normalize_delete_cascades(db):
+    """Align upgraded schemas with the cascades declared by create migrations."""
+    logger.info("Running migration: 20260716_01_normalize_delete_cascades")
+
+    cascade_contracts = (
+        ('bill_shares', 'bill_id', 'bills', 'id'),
+        ('category_budgets', 'database_id', 'databases', 'id'),
+        ('user_devices', 'user_id', 'users', 'id'),
+    )
+    for table_name, column_name, referred_table, referred_column in cascade_contracts:
+        _replace_fk_delete_action(
+            db,
+            table_name=table_name,
+            column_name=column_name,
+            referred_table=referred_table,
+            referred_column=referred_column,
+            ondelete='CASCADE',
+        )
+
+    db.session.commit()
+
+
 # List of all migrations in order
 # Format: (version, description, function)
 MIGRATIONS = [
@@ -942,6 +1027,7 @@ MIGRATIONS = [
     ('20260715_02', 'Add optimistic concurrency timestamp to bill shares', migrate_20260715_02_add_bill_share_updated_at),
     ('20260715_03', 'Create instance-wide telemetry consent settings', migrate_20260715_03_create_telemetry_settings),
     ('20260715_04', 'Add coarse user last-login tracking', migrate_20260715_04_add_user_last_login_at),
+    ('20260716_01', 'Normalize destructive foreign-key cascades', migrate_20260716_01_normalize_delete_cascades),
 ]
 
 

--- a/apps/server/models.py
+++ b/apps/server/models.py
@@ -307,7 +307,11 @@ class CategoryBudget(db.Model):
     __tablename__ = 'category_budgets'
 
     id = db.Column(db.Integer, primary_key=True)
-    database_id = db.Column(db.Integer, db.ForeignKey('databases.id'), nullable=False)
+    database_id = db.Column(
+        db.Integer,
+        db.ForeignKey('databases.id', ondelete='CASCADE'),
+        nullable=False,
+    )
     category = db.Column(db.String(50), nullable=False)
     monthly_limit = db.Column(db.Float, nullable=False)
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
@@ -340,7 +344,11 @@ class UserDevice(db.Model):
     """Stores registered devices for push notifications"""
     __tablename__ = 'user_devices'
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.id', ondelete='CASCADE'),
+        nullable=False,
+    )
 
     # Device identification
     device_id = db.Column(db.String(255), nullable=False)  # Unique device identifier
@@ -572,7 +580,11 @@ class BillShare(db.Model):
     """Tracks bill sharing between different users/accounts"""
     __tablename__ = 'bill_shares'
     id = db.Column(db.Integer, primary_key=True)
-    bill_id = db.Column(db.Integer, db.ForeignKey('bills.id'), nullable=False)
+    bill_id = db.Column(
+        db.Integer,
+        db.ForeignKey('bills.id', ondelete='CASCADE'),
+        nullable=False,
+    )
 
     # Who owns the bill (the user who created the share)
     owner_user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)

--- a/apps/server/tests/test_fk_delete_contracts.py
+++ b/apps/server/tests/test_fk_delete_contracts.py
@@ -1,0 +1,173 @@
+"""Database-level delete contracts shared by every deployment mode."""
+
+import pytest
+from sqlalchemy import inspect, text
+
+from db_migrations import _replace_fk_delete_action
+from models import Bill, BillShare, CategoryBudget, Database, User, UserDevice, db
+
+
+CASCADE_CONTRACTS = (
+    ("bill_shares", "bill_id", "bills"),
+    ("category_budgets", "database_id", "databases"),
+    ("user_devices", "user_id", "users"),
+)
+
+
+@pytest.mark.parametrize("table_name,column_name,referred_table", CASCADE_CONTRACTS)
+def test_model_declares_database_cascade(
+    table_name, column_name, referred_table
+):
+    foreign_keys = [
+        foreign_key
+        for foreign_key in db.metadata.tables[table_name].foreign_keys
+        if foreign_key.parent.name == column_name
+        and foreign_key.column.table.name == referred_table
+    ]
+
+    assert len(foreign_keys) == 1
+    assert foreign_keys[0].ondelete == "CASCADE"
+
+
+@pytest.mark.parametrize("table_name,column_name,referred_table", CASCADE_CONTRACTS)
+def test_fk_declares_database_cascade(
+    app, table_name, column_name, referred_table
+):
+    foreign_keys = inspect(db.engine).get_foreign_keys(table_name)
+    matches = [
+        foreign_key
+        for foreign_key in foreign_keys
+        if foreign_key["constrained_columns"] == [column_name]
+        and foreign_key["referred_table"] == referred_table
+    ]
+
+    assert len(matches) == 1
+    assert matches[0].get("options", {}).get("ondelete", "NO ACTION").upper() == "CASCADE"
+
+
+def test_migration_helper_upgrades_existing_no_action_constraint(app):
+    with app.app_context():
+        db.session.execute(text("DROP TABLE IF EXISTS fk_contract_child"))
+        db.session.execute(text("DROP TABLE IF EXISTS fk_contract_parent"))
+        db.session.execute(text('''
+            CREATE TABLE fk_contract_parent (
+                id INTEGER PRIMARY KEY
+            )
+        '''))
+        db.session.execute(text('''
+            CREATE TABLE fk_contract_child (
+                id INTEGER PRIMARY KEY,
+                parent_id INTEGER NOT NULL,
+                CONSTRAINT fk_contract_child_parent_id_fkey
+                    FOREIGN KEY (parent_id) REFERENCES fk_contract_parent(id)
+            )
+        '''))
+        db.session.commit()
+
+        try:
+            _replace_fk_delete_action(
+                db,
+                table_name="fk_contract_child",
+                column_name="parent_id",
+                referred_table="fk_contract_parent",
+                referred_column="id",
+                ondelete="CASCADE",
+            )
+            db.session.commit()
+
+            foreign_key = inspect(db.engine).get_foreign_keys("fk_contract_child")[0]
+            assert foreign_key["options"]["ondelete"] == "CASCADE"
+        finally:
+            db.session.rollback()
+            db.session.execute(text("DROP TABLE IF EXISTS fk_contract_child"))
+            db.session.execute(text("DROP TABLE IF EXISTS fk_contract_parent"))
+            db.session.commit()
+
+
+def test_deleting_user_cascades_registered_devices(db_session):
+    user = User(
+        username="fk-device-user",
+        email="fk-device-user@test.com",
+        role="user",
+    )
+    device = UserDevice(
+        user=user,
+        device_id="fk-device",
+        platform="ios",
+    )
+    db_session.add_all([user, device])
+    db_session.commit()
+    user_id = user.id
+    device_id = device.id
+
+    db_session.execute(User.__table__.delete().where(User.id == user_id))
+    db_session.commit()
+
+    assert db_session.get(UserDevice, device_id) is None
+
+
+def test_deleting_bill_cascades_bill_shares(db_session):
+    owner = User(
+        username="fk-share-owner",
+        email="fk-share-owner@test.com",
+        role="admin",
+    )
+    recipient = User(
+        username="fk-share-recipient",
+        email="fk-share-recipient@test.com",
+        role="user",
+        created_by=owner,
+    )
+    database = Database(
+        name="fk-share-db",
+        display_name="FK Share DB",
+        owner=owner,
+    )
+    bill = Bill(
+        database=database,
+        name="FK Share Bill",
+        amount=20.00,
+        frequency="monthly",
+        due_date="2026-08-01",
+        type="expense",
+    )
+    share = BillShare(
+        bill=bill,
+        owner=owner,
+        shared_with=recipient,
+        shared_with_identifier=recipient.username,
+        identifier_type="username",
+        status="accepted",
+    )
+    db_session.add_all([owner, recipient, database, bill, share])
+    db_session.commit()
+    bill_id = bill.id
+    share_id = share.id
+
+    db_session.execute(Bill.__table__.delete().where(Bill.id == bill_id))
+    db_session.commit()
+
+    assert db_session.get(BillShare, share_id) is None
+
+
+def test_deleting_database_cascades_category_budgets(db_session):
+    database = Database(
+        name="fk-budget-db",
+        display_name="FK Budget DB",
+    )
+    budget = CategoryBudget(
+        database=database,
+        category="Housing",
+        monthly_limit=1000.00,
+    )
+    db_session.add_all([database, budget])
+    db_session.commit()
+    database_id = database.id
+    budget_id = budget.id
+
+    db_session.execute(
+        Database.__table__.delete().where(Database.id == database_id)
+    )
+    db_session.commit()
+
+    assert db_session.get(CategoryBudget, budget_id) is None


### PR DESCRIPTION
## Summary

- adds a versioned migration that upgrades three existing NO ACTION constraints to the cascades their original create migrations intended
- aligns SQLAlchemy metadata so fresh installs and upgraded installs produce the same schema
- preserves each database-assigned constraint name while replacing its delete action
- fails migration explicitly if the expected foreign key is missing or ambiguous

## Normalized contracts

- bill_shares.bill_id to bills.id uses ON DELETE CASCADE
- category_budgets.database_id to databases.id uses ON DELETE CASCADE
- user_devices.user_id to users.id uses ON DELETE CASCADE

## Regression coverage

The new deployment-mode-neutral suite verifies:

- model metadata declares all three cascades
- the live PostgreSQL catalog declares all three cascades
- the migration helper upgrades an existing NO ACTION constraint
- direct parent deletes actually cascade shares, budgets, and devices

## Validation

- self-hosted backend: 191 passed, 12 intentionally skipped
- SaaS backend: 200 passed, 3 intentionally skipped
- focused FK contracts: 10 passed in each deployment mode
- Python compileall: passed
- Bandit: no issues identified
- pip-audit: no known vulnerabilities
- git diff --check: passed

## Context

Separate schema-normalization follow-up to #75, which retained explicit endpoint cleanup while avoiding a live-schema change in the replacement PR.
