### PR TITLE
Release v4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ A **secure multi-user** web application for tracking recurring expenses and inco
 
 ---
 
-## 🎉 What's New in v4.3.3
+## 🎉 What's New in v4.4.0
 
-**BillManager Mobile Alpha-1** - The native-adaptive mobile rewrite is now marked `1.0.0-alpha.1` for internal iOS and Android testing, alongside web and API fixes for one-time bills and shared-bill invitations.
+**Deletion Safety and Self-Hosted Reliability** - Account, user, bill, and bill-group deletion now handles related data safely across SaaS and self-hosted installations, with stronger PostgreSQL integrity contracts and full dual-mode backend coverage.
 
 ### Highlights
 
-- **Mobile Alpha-1** - Internal builds now show the Alpha-1 milestone while retaining the store-compatible native version `1.0.0`; this is not a public App Store or Google Play release
-- **Native-Adaptive Foundation** - The mobile client includes platform-specific iOS and Android navigation, encrypted offline data, local actionable reminders, biometric app lock, passkeys, and widgets for internal validation
-- **Correct One-Time Bills** - One-time bills stop producing future calendar, reminder, analytics, and optimistic-payment occurrences after completion
-- **Accurate Share Invitations** - Shared-bill invite details now use canonical owner and recipient fields while remaining compatible with older servers
+- **Safe Account Erasure** - Full account deletion now includes nested managed users and their bill groups, cancels live Stripe subscriptions first, and preserves local data if Stripe cannot confirm cancellation
+- **Reliable User and Bill Deletion** - Self-hosted and SaaS deletion paths clean up share history, authentication records, ownership, and access without foreign-key server errors or stranded data
+- **PostgreSQL Administrator Notice** - Migration `20260716_01` normalizes three delete cascades; it briefly locks and validates the affected tables, so multi-replica deployments should start one application instance first during a normal maintenance window
+- **Self-Hosted Parity** - Archived bills, bill-share access, reminder translations, and the complete backend suite now behave consistently outside SaaS mode
 
 ---
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -29,7 +29,7 @@ JWT_SECRET_KEY=change-this-to-another-random-64-char-string
 # Version values exposed by the pre-auth mobile compatibility contract.
 # APP_VERSION normally matches the deployed release/image tag.
 # Leave MINIMUM_MOBILE_VERSION empty unless older mobile binaries must be blocked.
-# APP_VERSION=4.3.3
+# APP_VERSION=4.4.0
 # MINIMUM_MOBILE_VERSION=
 
 # =============================================================================

--- a/apps/server/config.py
+++ b/apps/server/config.py
@@ -278,7 +278,7 @@ DEFAULT_LOCALE = os.environ.get("DEFAULT_LOCALE", "en-US")
 # version: it only changes when a mobile client must handle a breaking contract
 # change. An unset minimum version means that any client implementing the
 # advertised contract is accepted.
-SERVER_VERSION = os.environ.get("APP_VERSION", "4.3.3")
+SERVER_VERSION = os.environ.get("APP_VERSION", "4.4.0")
 MOBILE_CONTRACT_VERSION = 1
 MINIMUM_MOBILE_VERSION = os.environ.get("MINIMUM_MOBILE_VERSION") or None
 

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -14,7 +14,7 @@ info:
 
     Access tokens expire after 15 minutes. Refresh tokens expire after 7 days.
 
-  version: 4.3.3
+  version: 4.4.0
   license:
     name: O'Saasy License
     url: https://osaasy.dev/

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "4.3.3",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "4.3.3",
+      "version": "4.4.0",
       "dependencies": {
         "@mantine/charts": "^9.4.1",
         "@mantine/core": "^9.4.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "4.3.3",
+  "version": "4.4.0",
   "type": "module",
   "engines": {
     "node": ">=24.18.0 <25"

--- a/apps/web/src/config/releaseNotes.de.ts
+++ b/apps/web/src/config/releaseNotes.de.ts
@@ -2,6 +2,34 @@ import type { ReleaseNote } from './releaseNotes';
 
 export const germanReleaseNotes: ReleaseNote[] = [
   {
+    version: '4.4.0',
+    date: '2026-07-16',
+    title: 'Sicheres Löschen und zuverlässiges Self-Hosting',
+    sections: [
+      {
+        heading: 'Hinweis für Administratoren',
+        items: [
+          'Beim ersten Start nach dem Upgrade ersetzt die PostgreSQL-Migration 20260716_01 drei Fremdschlüssel und kann Schreibzugriffe kurz blockieren, während vorhandene Zeilen geprüft werden; verwenden Sie ein reguläres Wartungsfenster und starten Sie bei mehreren Replikaten zunächst nur eine Anwendungsinstanz',
+          'Es sind weder manuelle SQL-Befehle noch eine Datenkonvertierung erforderlich; die Migration gleicht das Löschen von Rechnungsfreigaben, Kategoriebudgets und registrierten Geräten an das von BillManager vorgesehene Schema an',
+        ],
+      },
+      {
+        heading: 'Sicherheit und Datenintegrität',
+        items: [
+          'Das vollständige Löschen eines Kontos umfasst jetzt verschachtelte verwaltete Nutzer und deren Rechnungsgruppen, beendet aktive Stripe-Abonnements zuerst und bewahrt lokale Daten, wenn Stripe die Kündigung nicht bestätigen kann',
+          'Beim Löschen von Nutzern, Rechnungen und Rechnungsgruppen werden abhängige Authentifizierungs-, Freigabe-, Eigentums- und Prüfdatensätze bereinigt, ohne weiter abrechenbare Abonnements oder Fremdschlüsselfehler zu hinterlassen',
+        ],
+      },
+      {
+        heading: 'Verbesserungen für Self-Hosting',
+        items: [
+          'Archivierte Rechnungen sind wieder erreichbar, der Zugriff auf geteilte Rechnungen funktioniert außerhalb des SaaS-Modus und die Erinnerungsleiste ist vollständig übersetzt',
+          'Die vollständige Backend-Testsuite läuft jetzt unabhängig im Self-Hosted- und SaaS-Modus, um installationsspezifische Regressionen zu erkennen',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.3.3',
     date: '2026-07-15',
     title: 'BillManager Mobile Alpha-1',

--- a/apps/web/src/config/releaseNotes.ts
+++ b/apps/web/src/config/releaseNotes.ts
@@ -5,7 +5,7 @@
  *
  * 1. Add a new entry at the TOP of the `releaseNotes` array (newest first)
  * 2. Update the version number in these files:
- *    - apps/server/app.py (search for 'version': - two occurrences)
+ *    - apps/server/config.py (SERVER_VERSION)
  *    - apps/server/openapi.yaml
  *    - apps/web/package.json
  *    - apps/web/package-lock.json
@@ -47,6 +47,34 @@ export interface ReleaseNote {
 }
 
 export const releaseNotes: ReleaseNote[] = [
+  {
+    version: '4.4.0',
+    date: '2026-07-16',
+    title: 'Deletion Safety and Self-Hosted Reliability',
+    sections: [
+      {
+        heading: 'Administrator Notice',
+        items: [
+          'On first startup after upgrading, PostgreSQL migration 20260716_01 replaces three foreign-key constraints and may briefly block writes while existing rows are validated; use a normal maintenance window and start one application replica first',
+          'No manual SQL or data conversion is required; the migration aligns bill-share, category-budget, and registered-device cleanup with the schema already intended by BillManager',
+        ],
+      },
+      {
+        heading: 'Security and Data Integrity',
+        items: [
+          'Full account erasure now includes nested managed users and their bill groups, cancels live Stripe subscriptions first, and preserves local data when Stripe cannot confirm cancellation',
+          'User, bill, and bill-group deletion now cleans up dependent authentication, sharing, ownership, and audit records without leaving billable subscriptions or triggering foreign-key server errors',
+        ],
+      },
+      {
+        heading: 'Self-Hosted Improvements',
+        items: [
+          'Archived bills are reachable again, shared-bill access works outside SaaS mode, and the reminder drawer is fully translated',
+          'The complete backend suite now runs independently in both self-hosted and SaaS modes to catch deployment-specific regressions',
+        ],
+      },
+    ],
+  },
   {
     version: '4.3.3',
     date: '2026-07-15',


### PR DESCRIPTION
## Summary

- bumps the server, OpenAPI, and web release version to 4.4.0
- adds matching English and German in-app release notes
- refreshes the README release highlights for deletion safety and self-hosted reliability
- adds an administrator-facing PostgreSQL notice for migration 20260716_01

## Administrator impact

On first startup after upgrading, migration 20260716_01 replaces the foreign-key delete actions for bill shares, category budgets, and registered devices. PostgreSQL briefly locks the affected tables while validating existing rows. Administrators should use a normal maintenance window and, for multi-replica deployments, start one application replica first and let it finish the migration before starting the rest. No manual SQL or data conversion is required.

## Included work

- self-hosted bill-share access and archived-bill fixes
- complete reminder-alert localization
- safe bill, bill-group, and user deletion in both deployment modes
- recursive account erasure with immediate, retry-safe Stripe cancellation
- normalized PostgreSQL cascade contracts
- complete backend test execution in separate self-hosted and SaaS processes

## Validation

- self-hosted backend: 192 passed, 17 intentionally skipped
- SaaS backend: 206 passed, 3 intentionally skipped
- web: 26 passed; lint completed with four existing hook warnings; production build passed
- mobile: 182 passed; lint, typecheck, generated API parity, Maestro, Expo compatibility, and Expo Doctor passed
- Bandit: no issues identified
- pip-audit: no known vulnerabilities
- Python compileall and git diff checks passed
