### PR TITLE
Release BillManager v4.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ A **secure multi-user** web application for tracking recurring expenses and inco
 
 ---
 
-## 🎉 What's New in v4.4.0
+## 🎉 What's New in v4.4.1
 
-**Deletion Safety and Self-Hosted Reliability** - Account, user, bill, and bill-group deletion now handles related data safely across SaaS and self-hosted installations, with stronger PostgreSQL integrity contracts and full dual-mode backend coverage.
+**Dependency and Toolchain Maintenance** - Web, mobile, backend, and CI dependencies are refreshed within their supported runtime lines, with Expo SDK 57 compatibility restored and no database or API migration required.
 
 ### Highlights
 
-- **Safe Account Erasure** - Full account deletion now includes nested managed users and their bill groups, cancels live Stripe subscriptions first, and preserves local data if Stripe cannot confirm cancellation
-- **Reliable User and Bill Deletion** - Self-hosted and SaaS deletion paths clean up share history, authentication records, ownership, and access without foreign-key server errors or stranded data
-- **PostgreSQL Administrator Notice** - Migration `20260716_01` normalizes three delete cascades; it briefly locks and validates the affected tables, so multi-replica deployments should start one application instance first during a normal maintenance window
-- **Self-Hosted Parity** - Archived bills, bill-share access, reminder translations, and the complete backend suite now behave consistently outside SaaS mode
+- **Expo SDK 57 Compatibility** - Expo runtime, navigation, form, icon, localization, and build packages now match the SDK's validated versions
+- **Web Toolchain Refresh** - Vite, TypeScript ESLint, Tabler icons, and React i18n packages are updated within their supported release lines
+- **Backend SDK Maintenance** - Resend and Stripe SDK updates add API improvements, corrected response handling, and lower Stripe client cold-start latency
+- **Current CI Runtime** - GitHub Actions now uses `setup-node@v7`, with all security, test, build, and multi-architecture image checks passing
 
 ---
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -29,7 +29,7 @@ JWT_SECRET_KEY=change-this-to-another-random-64-char-string
 # Version values exposed by the pre-auth mobile compatibility contract.
 # APP_VERSION normally matches the deployed release/image tag.
 # Leave MINIMUM_MOBILE_VERSION empty unless older mobile binaries must be blocked.
-# APP_VERSION=4.4.0
+# APP_VERSION=4.4.1
 # MINIMUM_MOBILE_VERSION=
 
 # =============================================================================

--- a/apps/server/config.py
+++ b/apps/server/config.py
@@ -278,7 +278,7 @@ DEFAULT_LOCALE = os.environ.get("DEFAULT_LOCALE", "en-US")
 # version: it only changes when a mobile client must handle a breaking contract
 # change. An unset minimum version means that any client implementing the
 # advertised contract is accepted.
-SERVER_VERSION = os.environ.get("APP_VERSION", "4.4.0")
+SERVER_VERSION = os.environ.get("APP_VERSION", "4.4.1")
 MOBILE_CONTRACT_VERSION = 1
 MINIMUM_MOBILE_VERSION = os.environ.get("MINIMUM_MOBILE_VERSION") or None
 

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -14,7 +14,7 @@ info:
 
     Access tokens expire after 15 minutes. Refresh tokens expire after 7 days.
 
-  version: 4.4.0
+  version: 4.4.1
   license:
     name: O'Saasy License
     url: https://osaasy.dev/

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "dependencies": {
         "@mantine/charts": "^9.4.1",
         "@mantine/core": "^9.4.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "4.4.0",
+  "version": "4.4.1",
   "type": "module",
   "engines": {
     "node": ">=24.18.0 <25"

--- a/apps/web/src/config/releaseNotes.de.ts
+++ b/apps/web/src/config/releaseNotes.de.ts
@@ -2,6 +2,27 @@ import type { ReleaseNote } from './releaseNotes';
 
 export const germanReleaseNotes: ReleaseNote[] = [
   {
+    version: '4.4.1',
+    date: '2026-07-19',
+    title: 'Abhängigkeits- und Toolchain-Wartung',
+    sections: [
+      {
+        heading: 'Verbesserungen',
+        items: [
+          'Die Laufzeit-, Navigations-, Formular-, Symbol-, Lokalisierungs- und Build-Pakete von Expo SDK 57 entsprechen jetzt den validierten Versionen für interne iOS- und Android-Builds',
+          'Compiler-, Lint-, Symbol- und Lokalisierungsabhängigkeiten der Webanwendung wurden aktualisiert und GitHub Actions verwendet jetzt die aktuelle Node-Einrichtungsaktion',
+        ],
+      },
+      {
+        heading: 'Backend-Zuverlässigkeit',
+        items: [
+          'Die Resend- und Stripe-SDKs wurden für zusätzliche API-Funktionen, korrigierte Antwort- und Fehlerbehandlung sowie eine geringere Startlatenz des Stripe-Clients aktualisiert',
+          'Die Abhängigkeitsprüfungen fanden keine bekannten Schwachstellen; für diese Wartungsversion ist keine Datenbank- oder API-Migration erforderlich',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.4.0',
     date: '2026-07-16',
     title: 'Sicheres Löschen und zuverlässiges Self-Hosting',

--- a/apps/web/src/config/releaseNotes.ts
+++ b/apps/web/src/config/releaseNotes.ts
@@ -48,6 +48,27 @@ export interface ReleaseNote {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '4.4.1',
+    date: '2026-07-19',
+    title: 'Dependency and Toolchain Maintenance',
+    sections: [
+      {
+        heading: 'Improvements',
+        items: [
+          'Updated the Expo SDK 57 runtime, navigation, form, icon, localization, and build packages to the versions validated for internal iOS and Android builds',
+          'Refreshed the web compiler, lint, icon, and localization dependencies and moved GitHub Actions to the current Node setup action',
+        ],
+      },
+      {
+        heading: 'Backend Reliability',
+        items: [
+          'Updated the Resend and Stripe SDKs for additive API improvements, corrected response and error handling, and reduced Stripe client cold-start latency',
+          'Dependency audits found no known vulnerabilities, and this maintenance release requires no database or API migration',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.4.0',
     date: '2026-07-16',
     title: 'Deletion Safety and Self-Hosted Reliability',


### PR DESCRIPTION
## Summary

- bump BillManager from 4.4.0 to 4.4.1 across runtime and package metadata
- add English and German release notes for the weekly dependency/toolchain maintenance
- document the v4.4.1 maintenance highlights in the README

## Why

PR #79 safely updates the supported Node.js action plus Stripe and Resend dependencies. This patch release publishes those verified maintenance updates without database or API migrations.

## Impact

- patch release only
- no database migration
- no API migration
- no product behavior change expected beyond dependency fixes and improvements

## Verification

- backend: dependency audit and Bandit passed; pytest 206 passed, 3 skipped
- web: npm audit 0; 26 tests passed; lint 0 errors; production build passed
- mobile: npm audit 0; 182 tests passed; lint, typecheck, config validation, Expo checks, and 6 Maestro flows passed
- production Docker image build passed
- git diff --check passed