### PR TITLE
Release BillManager v4.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,15 @@ A **secure multi-user** web application for tracking recurring expenses and inco
 
 ---
 
-## 🎉 What's New in v4.6.0
+## 🎉 What's New in v4.6.1
 
-**Unified Settings and Personal Currency** - The complete tabbed Settings experience is accessible from the application again, and every user can choose their own display currency on web or mobile.
+**Currency Preference Reliability** - Personal currency now remains active while changing mobile language, and generated API clients receive the complete login contract.
 
 ### Highlights
 
-- **Reachable Settings** - The application menu now opens the full `/settings` page instead of hiding administration in a modal
-- **Tabbed Administration** - Administrators can manage account settings, users, and bill groups from one responsive page with direct-linkable tabs
-- **Personal Currency** - Each user can select USD, EUR, JPY, GBP, CNY, CHF, AUD, CAD, HKD, SGD, INR, KRW, SEK, NZD, or MXN independently
-- **Cross-Device Preference** - Currency changes persist to the account and are applied on both web and mobile
-- **Safe Upgrade** - Existing installations inherit their former `DEFAULT_CURRENCY` once during migration; currency is no longer a runtime environment setting
+- **Stable Mobile Formatting** - Changing language no longer resets formatting or money-input precision to the server default currency
+- **Complete API Contract** - The documented and generated login response now includes the authenticated user's currency
+- **Regression Coverage** - Mobile behavior and OpenAPI generation are protected by focused tests
 
 ---
 

--- a/apps/mobile/src/api/generated/schema.ts
+++ b/apps/mobile/src/api/generated/schema.ts
@@ -2058,9 +2058,11 @@ export interface components {
                 /** @example Bearer */
                 token_type?: string;
                 user?: {
-                    id?: number;
-                    username?: string;
-                    role?: string;
+                    id: number;
+                    username: string;
+                    role: string;
+                    /** @enum {string} */
+                    currency: "USD" | "EUR" | "JPY" | "GBP" | "CNY" | "CHF" | "AUD" | "CAD" | "HKD" | "SGD" | "INR" | "KRW" | "SEK" | "NZD" | "MXN";
                 };
                 databases?: components["schemas"]["DatabaseInfo"][];
             };

--- a/apps/mobile/src/features/settings/LanguageRegionScreen.shared.tsx
+++ b/apps/mobile/src/features/settings/LanguageRegionScreen.shared.tsx
@@ -17,7 +17,7 @@ import {
   setLanguage,
   type SupportedLanguage,
 } from '../../i18n';
-import { formatLocaleExample } from './settingsModel';
+import { formatLocaleExample, resolveUserCurrency } from './settingsModel';
 import {
   SettingsAction,
   SettingsChoiceRow,
@@ -47,7 +47,7 @@ export function LanguageRegionScreenView({
       await setLanguage(nextLanguage);
       setFormatting(configureFormatting(
         activeProfile.capabilities?.defaultLocale,
-        activeProfile.capabilities?.defaultCurrency,
+        resolveUserCurrency(user?.currency, activeProfile.capabilities?.defaultCurrency),
         nextLanguage,
       ));
       void Haptics.selectionAsync();

--- a/apps/mobile/src/features/settings/settingsModel.test.ts
+++ b/apps/mobile/src/features/settings/settingsModel.test.ts
@@ -4,9 +4,16 @@ import {
   buildMobileVersionInfo,
   formatLocaleExample,
   resolveTelemetryStatus,
+  resolveUserCurrency,
 } from './settingsModel';
 
 describe('settings model', () => {
+  it('preserves the authenticated user currency over the server default', () => {
+    expect(resolveUserCurrency('EUR', 'USD')).toBe('EUR');
+    expect(resolveUserCurrency(undefined, 'USD')).toBe('USD');
+    expect(resolveUserCurrency(null, null)).toBeUndefined();
+  });
+
   it('keeps telemetry undecided until the owner makes a choice', () => {
     expect(resolveTelemetryStatus({
       show_notice: true,

--- a/apps/mobile/src/features/settings/settingsModel.ts
+++ b/apps/mobile/src/features/settings/settingsModel.ts
@@ -14,6 +14,13 @@ export type TelemetryStatus =
   | 'managed'
   | 'unavailable';
 
+export function resolveUserCurrency(
+  userCurrency?: string | null,
+  serverDefaultCurrency?: string | null,
+): string | undefined {
+  return userCurrency || serverDefaultCurrency || undefined;
+}
+
 export function resolveTelemetryStatus(
   state: TelemetryNoticeState | null,
   isAccountOwner: boolean,

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -29,7 +29,7 @@ JWT_SECRET_KEY=change-this-to-another-random-64-char-string
 # Version values exposed by the pre-auth mobile compatibility contract.
 # APP_VERSION normally matches the deployed release/image tag.
 # Leave MINIMUM_MOBILE_VERSION empty unless older mobile binaries must be blocked.
-# APP_VERSION=4.6.0
+# APP_VERSION=4.6.1
 # MINIMUM_MOBILE_VERSION=
 
 # =============================================================================

--- a/apps/server/config.py
+++ b/apps/server/config.py
@@ -307,7 +307,7 @@ DEFAULT_LOCALE = os.environ.get("DEFAULT_LOCALE", "en-US")
 # version: it only changes when a mobile client must handle a breaking contract
 # change. An unset minimum version means that any client implementing the
 # advertised contract is accepted.
-SERVER_VERSION = os.environ.get("APP_VERSION", "4.6.0")
+SERVER_VERSION = os.environ.get("APP_VERSION", "4.6.1")
 MOBILE_CONTRACT_VERSION = 1
 MINIMUM_MOBILE_VERSION = os.environ.get("MINIMUM_MOBILE_VERSION") or None
 

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -14,7 +14,7 @@ info:
 
     Access tokens expire after 15 minutes. Refresh tokens expire after 7 days.
 
-  version: 4.6.0
+  version: 4.6.1
   license:
     name: O'Saasy License
     url: https://osaasy.dev/
@@ -3722,6 +3722,7 @@ components:
               example: Bearer
             user:
               type: object
+              required: [id, username, role, currency]
               properties:
                 id:
                   type: integer
@@ -3729,6 +3730,9 @@ components:
                   type: string
                 role:
                   type: string
+                currency:
+                  type: string
+                  enum: [USD, EUR, JPY, GBP, CNY, CHF, AUD, CAD, HKD, SGD, INR, KRW, SEK, NZD, MXN]
             databases:
               type: array
               items:

--- a/apps/server/tests/test_mobile_contracts.py
+++ b/apps/server/tests/test_mobile_contracts.py
@@ -244,6 +244,9 @@ def test_openapi_default_currency_schemas_use_ordered_supported_enum():
 
     assert schemas["PublicConfig"]["properties"]["default_currency"]["enum"] == expected
     assert schemas["MobileCapabilities"]["properties"]["default_currency"]["enum"] == expected
+    login_user = schemas["LoginResponse"]["properties"]["data"]["properties"]["user"]
+    assert "currency" in login_user["required"]
+    assert login_user["properties"]["currency"]["enum"] == expected
 
 
 def test_authenticated_password_change_requires_current_password(

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "dependencies": {
         "@mantine/charts": "^8.3.10",
         "@mantine/core": "^8.3.10",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "4.6.0",
+  "version": "4.6.1",
   "type": "module",
   "engines": {
     "node": ">=24.18.0 <25"

--- a/apps/web/src/config/releaseNotes.de.ts
+++ b/apps/web/src/config/releaseNotes.de.ts
@@ -2,6 +2,20 @@ import type { ReleaseNote } from './releaseNotes';
 
 export const germanReleaseNotes: ReleaseNote[] = [
   {
+    version: '4.6.1',
+    date: '2026-07-24',
+    title: 'Zuverlässige Währungseinstellungen',
+    sections: [
+      {
+        heading: 'Fehlerbehebungen',
+        items: [
+          'Beim Ändern der mobilen Oberflächensprache bleiben die ausgewählte Benutzerwährung und die Genauigkeit der Betragseingabe erhalten',
+          'Der veröffentlichte Anmelde-API-Vertrag enthält jetzt die Benutzerwährung, die generierte Clients direkt nach der Anmeldung verwenden',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.6.0',
     date: '2026-07-24',
     title: 'Einheitliche Einstellungen und persönliche Währung',

--- a/apps/web/src/config/releaseNotes.ts
+++ b/apps/web/src/config/releaseNotes.ts
@@ -48,6 +48,20 @@ export interface ReleaseNote {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '4.6.1',
+    date: '2026-07-24',
+    title: 'Currency Preference Reliability',
+    sections: [
+      {
+        heading: 'Bug Fixes',
+        items: [
+          'Changing the mobile interface language now preserves the signed-in user\'s selected currency and money-input precision',
+          'The published login API contract now includes the user currency used by generated clients immediately after authentication',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.6.0',
     date: '2026-07-24',
     title: 'Unified Settings and Personal Currency',


### PR DESCRIPTION
## Summary
- preserve the authenticated user's currency when changing the mobile interface language
- document user.currency in LoginResponse and regenerate the mobile API schema
- add focused regressions and v4.6.1 release metadata

## Review feedback addressed
- closes the behavior identified in PR #81 discussion r3646133125
- closes the API contract gap identified in PR #81 discussion r3646133130

## Validation
- backend: full suite in self-hosted and SaaS modes
- web: 60 tests, lint, production build
- mobile: 225 tests, typecheck, lint, localization, Maestro, and build-profile validation
- generated API schema synchronization
- Bandit and pip-audit clean
