### PR TITLE
Release BillManager v4.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ A **secure multi-user** web application for tracking recurring expenses and inco
 
 ---
 
-## 🎉 What's New in v4.7.0
+## 🎉 What's New in v4.7.1
 
-**Modernized Application Platform** - BillManager now runs on React Router 8 and Mantine 9, with coordinated stable dependency updates across web, mobile, and backend services.
+**Compact Responsive Layout** - Dashboard and navigation spacing now adapt cleanly to scaled displays and narrower desktop viewports.
 
 ### Highlights
 
-- **Modern Web Foundation** - React Router 8, Mantine 9, React 19.2, Vite 8.2, and the refreshed browser test stack are validated together
-- **Responsive Navigation** - Compact mobile header actions keep bill-group selection, theme, administration, and sign-out controls accessible
-- **Stable Mobile Maintenance** - Expo SDK 57, React Native 0.86, navigation, query, forms, icons, and supporting packages use compatible stable updates
-- **Safe Upgrade** - Backend SDKs are refreshed, PostgreSQL 17 remains supported, and no database migration is required
+- **Denser Navigation** - Sidebar links no longer combine link padding with duplicate external gaps
+- **Responsive Dashboard** - Compact desktop layouts use a narrower sidebar, tighter content spacing, and shorter stat cards
+- **Stable Actions** - Summary icons and bill actions stay aligned instead of wrapping into tall rows
+- **Contained Mobile Tables** - Upcoming bills scroll within their panel without widening the page
 
 ---
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -29,7 +29,7 @@ JWT_SECRET_KEY=change-this-to-another-random-64-char-string
 # Version values exposed by the pre-auth mobile compatibility contract.
 # APP_VERSION normally matches the deployed release/image tag.
 # Leave MINIMUM_MOBILE_VERSION empty unless older mobile binaries must be blocked.
-# APP_VERSION=4.7.0
+# APP_VERSION=4.7.1
 # MINIMUM_MOBILE_VERSION=
 
 # =============================================================================

--- a/apps/server/config.py
+++ b/apps/server/config.py
@@ -307,7 +307,7 @@ DEFAULT_LOCALE = os.environ.get("DEFAULT_LOCALE", "en-US")
 # version: it only changes when a mobile client must handle a breaking contract
 # change. An unset minimum version means that any client implementing the
 # advertised contract is accepted.
-SERVER_VERSION = os.environ.get("APP_VERSION", "4.7.0")
+SERVER_VERSION = os.environ.get("APP_VERSION", "4.7.1")
 MOBILE_CONTRACT_VERSION = 1
 MINIMUM_MOBILE_VERSION = os.environ.get("MINIMUM_MOBILE_VERSION") or None
 

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -14,7 +14,7 @@ info:
 
     Access tokens expire after 15 minutes. Refresh tokens expire after 7 days.
 
-  version: 4.7.0
+  version: 4.7.1
   license:
     name: O'Saasy License
     url: https://osaasy.dev/

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "dependencies": {
         "@mantine/charts": "^9.5.0",
         "@mantine/core": "^9.5.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "4.7.0",
+  "version": "4.7.1",
   "type": "module",
   "engines": {
     "node": ">=24.18.0 <25"

--- a/apps/web/src/components/Dashboard/StatCards.tsx
+++ b/apps/web/src/components/Dashboard/StatCards.tsx
@@ -58,9 +58,9 @@ export function StatCards({ bills, monthlyPaid, onStatClick }: StatCardsProps) {
   const monthlyTotal = monthlyPaid + monthlyRemaining;
 
   return (
-    <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="md">
-      <Paper withBorder p="md" radius="md" style={{ cursor: 'pointer' }} onClick={() => onStatClick('total')}>
-        <Group justify="space-between">
+    <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="sm">
+      <Paper withBorder p="sm" radius="md" style={{ cursor: 'pointer' }} onClick={() => onStatClick('total')}>
+        <Group justify="space-between" wrap="nowrap">
           <div>
             <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
               {t('dashboard.statCards.totalBills')}
@@ -69,14 +69,14 @@ export function StatCards({ bills, monthlyPaid, onStatClick }: StatCardsProps) {
               {totalBills}
             </Text>
           </div>
-          <ThemeIcon color="blue" variant="light" size="lg" radius="md">
+          <ThemeIcon color="blue" variant="light" size="lg" radius="md" style={{ flexShrink: 0 }}>
             <IconReceipt size={20} />
           </ThemeIcon>
         </Group>
       </Paper>
 
-      <Paper withBorder p="md" radius="md" style={{ cursor: 'pointer' }} onClick={() => onStatClick('thisWeek')}>
-        <Group justify="space-between">
+      <Paper withBorder p="sm" radius="md" style={{ cursor: 'pointer' }} onClick={() => onStatClick('thisWeek')}>
+        <Group justify="space-between" wrap="nowrap">
           <div>
             <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
               {t('dashboard.statCards.dueThisWeek')}
@@ -85,14 +85,14 @@ export function StatCards({ bills, monthlyPaid, onStatClick }: StatCardsProps) {
               {dueThisWeek}
             </Text>
           </div>
-          <ThemeIcon color="orange" variant="light" size="lg" radius="md">
+          <ThemeIcon color="orange" variant="light" size="lg" radius="md" style={{ flexShrink: 0 }}>
             <IconCalendar size={20} />
           </ThemeIcon>
         </Group>
       </Paper>
 
-      <Paper withBorder p="md" radius="md" style={{ cursor: 'pointer' }} onClick={() => onStatClick('overdue')}>
-        <Group justify="space-between">
+      <Paper withBorder p="sm" radius="md" style={{ cursor: 'pointer' }} onClick={() => onStatClick('overdue')}>
+        <Group justify="space-between" wrap="nowrap">
           <div>
             <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
               {t('dashboard.statCards.overdue')}
@@ -101,28 +101,28 @@ export function StatCards({ bills, monthlyPaid, onStatClick }: StatCardsProps) {
               {overdue}
             </Text>
           </div>
-          <ThemeIcon color={overdue > 0 ? 'red' : 'gray'} variant="light" size="lg" radius="md">
+          <ThemeIcon color={overdue > 0 ? 'red' : 'gray'} variant="light" size="lg" radius="md" style={{ flexShrink: 0 }}>
             <IconAlertTriangle size={20} />
           </ThemeIcon>
         </Group>
       </Paper>
 
-      <Paper withBorder p="md" radius="md">
-        <Group justify="space-between" align="flex-start">
-          <Stack gap={2}>
+      <Paper withBorder p="sm" radius="md">
+        <Group justify="space-between" align="flex-start" wrap="nowrap">
+          <Stack gap={2} style={{ flex: 1, minWidth: 0 }}>
             <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
               {t('dashboard.statCards.monthlyTotal')}
             </Text>
             <Text fw={700} size="xl" c="green">
               {formatCurrency(monthlyTotal)}
             </Text>
-            <Group gap="xs">
+            <Group gap={4} wrap="wrap">
               <Text size="xs" c="green.6" fw={500}>{t('dashboard.statCards.paid', { amount: formatCurrency(monthlyPaid) })}</Text>
               <Text size="xs" c="dimmed">|</Text>
               <Text size="xs" c="orange.6" fw={500}>{t('dashboard.statCards.remaining', { amount: formatCurrency(monthlyRemaining) })}</Text>
             </Group>
           </Stack>
-          <ThemeIcon color="green" variant="light" size="lg" radius="md">
+          <ThemeIcon color="green" variant="light" size="lg" radius="md" style={{ flexShrink: 0 }}>
             <IconCoin size={20} />
           </ThemeIcon>
         </Group>

--- a/apps/web/src/components/Dashboard/UpcomingBillsList.tsx
+++ b/apps/web/src/components/Dashboard/UpcomingBillsList.tsx
@@ -1,5 +1,6 @@
 import { Paper, Title, Text, Group, Button, Table, Badge, ThemeIcon, ActionIcon, Tooltip } from '@mantine/core';
 import { IconCalendar, IconCash, IconEdit, IconUsers } from '@tabler/icons-react';
+import { useMediaQuery } from '@mantine/hooks';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import type { Bill } from '../../api/client';
@@ -73,6 +74,7 @@ function getFrequencyText(bill: Bill, t: TFunction): string {
 
 export function UpcomingBillsList({ bills, onPay, onEdit, onViewPayments, onViewAll }: UpcomingBillsListProps) {
   const { t } = useTranslation();
+  const isMobile = useMediaQuery('(max-width: 768px)');
 
   // Get today's date at midnight
   const today = new Date();
@@ -109,23 +111,24 @@ export function UpcomingBillsList({ bills, onPay, onEdit, onViewPayments, onView
           {t('dashboard.upcomingBills.empty')}
         </Text>
       ) : (
-        <Table striped highlightOnHover>
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th>{t('common.table.name')}</Table.Th>
-              <Table.Th>{t('common.table.amount')}</Table.Th>
-              <Table.Th>{t('common.table.dueDate')}</Table.Th>
-              <Table.Th>{t('common.table.frequency')}</Table.Th>
-              <Table.Th>{t('common.table.actions')}</Table.Th>
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
-            {upcomingBills.map((bill) => (
-              <Table.Tr
-                key={bill.id}
-                style={{ cursor: 'pointer' }}
-                onClick={() => onViewPayments(bill)}
-              >
+        <Table.ScrollContainer minWidth={640}>
+          <Table striped highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>{t('common.table.name')}</Table.Th>
+                <Table.Th>{t('common.table.amount')}</Table.Th>
+                <Table.Th>{t('common.table.dueDate')}</Table.Th>
+                <Table.Th>{t('common.table.frequency')}</Table.Th>
+                <Table.Th>{t('common.table.actions')}</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {upcomingBills.map((bill) => (
+                <Table.Tr
+                  key={bill.id}
+                  style={{ cursor: 'pointer' }}
+                  onClick={() => onViewPayments(bill)}
+                >
                 <Table.Td>
                   <Group gap="sm">
                     <BillIcon icon={bill.icon} size={24} />
@@ -205,7 +208,7 @@ export function UpcomingBillsList({ bills, onPay, onEdit, onViewPayments, onView
                   </Text>
                 </Table.Td>
                 <Table.Td>
-                  <Group gap="xs" onClick={(e) => e.stopPropagation()}>
+                  <Group gap="xs" wrap={isMobile ? 'wrap' : 'nowrap'} onClick={(e) => e.stopPropagation()}>
                     {!bill.is_shared && (
                       <>
                         <ActionIcon
@@ -238,10 +241,11 @@ export function UpcomingBillsList({ bills, onPay, onEdit, onViewPayments, onView
                     )}
                   </Group>
                 </Table.Td>
-              </Table.Tr>
-            ))}
-          </Table.Tbody>
-        </Table>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
       )}
     </Paper>
   );

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -32,6 +32,7 @@ export function Layout({ children, sidebar, onSettingsClick, onBillingClick }: L
   const { isLoggedIn, isAdmin, databases, currentDb, selectDatabase, logout } = useAuth();
   const [scroll, scrollTo] = useWindowScroll();
   const isMobile = useMediaQuery('(max-width: 768px)');
+  const isCompactDesktop = useMediaQuery('(max-width: 1400px)');
 
   const handleDatabaseChange = (value: string | null) => {
     if (value) {
@@ -41,7 +42,7 @@ export function Layout({ children, sidebar, onSettingsClick, onBillingClick }: L
 
   return (
     <>
-      <AppShell header={{ height: 60 }} padding="md">
+      <AppShell header={{ height: 60 }} padding={isCompactDesktop ? 'sm' : 'md'}>
         <AppShell.Header>
           <Group h="100%" px={isMobile ? 'xs' : 'md'} justify="space-between" wrap="nowrap">
             <Group gap={isMobile ? 'xs' : 'md'} wrap="nowrap">
@@ -155,10 +156,10 @@ export function Layout({ children, sidebar, onSettingsClick, onBillingClick }: L
         </AppShell.Header>
 
         <AppShell.Main>
-          <Group align="flex-start" wrap="nowrap" gap="md">
+          <Group align="flex-start" wrap="nowrap" gap={isCompactDesktop ? 'sm' : 'md'}>
             {/* Sidebar - hidden on mobile, shown via drawer */}
             {!isMobile && (
-              <Box w={285} style={{ flexShrink: 0 }}>
+              <Box w={isCompactDesktop ? 240 : 285} style={{ flexShrink: 0 }}>
                 {sidebar}
               </Box>
             )}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -87,7 +87,7 @@ export function Sidebar({ bills, isLoggedIn, filter, onFilterChange }: SidebarPr
     <Stack gap="xs">
       {/* Navigation Links */}
       {isLoggedIn && (
-        <>
+        <Stack gap={0}>
           <NavLink
             label={t('sidebar.navDashboard')}
             leftSection={<IconHome size={16} />}
@@ -131,7 +131,7 @@ export function Sidebar({ bills, isLoggedIn, filter, onFilterChange }: SidebarPr
             variant="light"
           />
           <Divider my="xs" />
-        </>
+        </Stack>
       )}
 
       <Title order={6}>

--- a/apps/web/src/config/releaseNotes.de.ts
+++ b/apps/web/src/config/releaseNotes.de.ts
@@ -2,6 +2,20 @@ import type { ReleaseNote } from './releaseNotes';
 
 export const germanReleaseNotes: ReleaseNote[] = [
   {
+    version: '4.7.1',
+    date: '2026-07-30',
+    title: 'Kompaktes responsives Layout',
+    sections: [
+      {
+        heading: 'Verbesserungen',
+        items: [
+          'Doppelte Abstände in Seitenleiste und Dashboard wurden auf skalierten Displays und schmaleren Desktop-Ansichten reduziert',
+          'Übersichtssymbole und Rechnungsaktionen bleiben ausgerichtet, während breite Tabellen auf Mobilgeräten innerhalb ihres Bereichs scrollen',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.7.0',
     date: '2026-07-30',
     title: 'Modernisierte Anwendungsplattform',

--- a/apps/web/src/config/releaseNotes.ts
+++ b/apps/web/src/config/releaseNotes.ts
@@ -50,6 +50,20 @@ export interface ReleaseNote {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '4.7.1',
+    date: '2026-07-30',
+    title: 'Compact Responsive Layout',
+    sections: [
+      {
+        heading: 'Improvements',
+        items: [
+          'Reduced duplicate sidebar and dashboard spacing on scaled displays and narrower desktop viewports',
+          'Kept summary icons and bill actions aligned while containing wide upcoming-bill tables on mobile screens',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.7.0',
     date: '2026-07-30',
     title: 'Modernized Application Platform',

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -74,7 +74,7 @@ export function Dashboard({
   }
 
   return (
-    <Stack gap="lg">
+    <Stack gap="md">
       {/* Header */}
       <Group justify="space-between" align="center">
         <Title order={2}>{t('sidebar.navDashboard')}</Title>
@@ -87,7 +87,7 @@ export function Dashboard({
       <StatCards bills={bills} monthlyPaid={monthlyPaid} onStatClick={onStatClick} />
 
       {/* Content Grid */}
-      <Grid>
+      <Grid gap="sm">
         <Grid.Col span={{ base: 12, md: 8 }}>
           {/* Upcoming Bills */}
           <UpcomingBillsList


### PR DESCRIPTION
## What changed

- Reduce duplicate navigation and dashboard spacing at scaled and narrower desktop widths
- Use a compact sidebar and app-shell gutter below 1400px
- Keep dashboard summary icons and bill actions aligned without tall wrapped rows
- Contain upcoming-bill tables on mobile
- Bump the packaged application version and release notes to 4.7.1

## Why

The v4.7.0 UI was functionally correct, but responsive pressure at the deployed viewport caused Mantine groups and table actions to wrap. Combined with duplicate sidebar gaps, this made the dashboard look excessively padded and double-spaced.

## Validation

- Web unit tests: 60 passed
- Web lint: 0 errors (4 pre-existing React hook warnings)
- Production web build: passed
- Backend self-hosted and SaaS suites: passed
- SaaS backend result: 303 passed, 3 skipped
- Responsive Playwright smoke: 1311px desktop and 390px mobile, no page overflow