### PR TITLE
Release BillManager v4.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ A **secure multi-user** web application for tracking recurring expenses and inco
 
 ---
 
-## 🎉 What's New in v4.7.1
+## 🎉 What's New in v4.7.2
 
-**Compact Responsive Layout** - Dashboard and navigation spacing now adapt cleanly to scaled displays and narrower desktop viewports.
+**Aligned Dashboard Actions** - The Quick Actions panel now matches the Monthly Total card width on wide desktop layouts.
 
 ### Highlights
 
-- **Denser Navigation** - Sidebar links no longer combine link padding with duplicate external gaps
-- **Responsive Dashboard** - Compact desktop layouts use a narrower sidebar, tighter content spacing, and shorter stat cards
-- **Stable Actions** - Summary icons and bill actions stay aligned instead of wrapping into tall rows
-- **Contained Mobile Tables** - Upcoming bills scroll within their panel without widening the page
+- **Consistent Columns** - Quick Actions uses the same quarter-width dashboard column as Monthly Total
+- **More Bill Space** - Upcoming Bills gains the remaining desktop width for clearer table content
+- **Responsive Balance** - Tablet layouts retain the roomier one-third action column
+- **No Mobile Regression** - Phone layouts continue stacking panels at full width
 
 ---
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -29,7 +29,7 @@ JWT_SECRET_KEY=change-this-to-another-random-64-char-string
 # Version values exposed by the pre-auth mobile compatibility contract.
 # APP_VERSION normally matches the deployed release/image tag.
 # Leave MINIMUM_MOBILE_VERSION empty unless older mobile binaries must be blocked.
-# APP_VERSION=4.7.1
+# APP_VERSION=4.7.2
 # MINIMUM_MOBILE_VERSION=
 
 # =============================================================================

--- a/apps/server/config.py
+++ b/apps/server/config.py
@@ -307,7 +307,7 @@ DEFAULT_LOCALE = os.environ.get("DEFAULT_LOCALE", "en-US")
 # version: it only changes when a mobile client must handle a breaking contract
 # change. An unset minimum version means that any client implementing the
 # advertised contract is accepted.
-SERVER_VERSION = os.environ.get("APP_VERSION", "4.7.1")
+SERVER_VERSION = os.environ.get("APP_VERSION", "4.7.2")
 MOBILE_CONTRACT_VERSION = 1
 MINIMUM_MOBILE_VERSION = os.environ.get("MINIMUM_MOBILE_VERSION") or None
 

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -14,7 +14,7 @@ info:
 
     Access tokens expire after 15 minutes. Refresh tokens expire after 7 days.
 
-  version: 4.7.1
+  version: 4.7.2
   license:
     name: O'Saasy License
     url: https://osaasy.dev/

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "dependencies": {
         "@mantine/charts": "^9.5.0",
         "@mantine/core": "^9.5.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "4.7.1",
+  "version": "4.7.2",
   "type": "module",
   "engines": {
     "node": ">=24.18.0 <25"

--- a/apps/web/src/config/releaseNotes.de.ts
+++ b/apps/web/src/config/releaseNotes.de.ts
@@ -2,6 +2,20 @@ import type { ReleaseNote } from './releaseNotes';
 
 export const germanReleaseNotes: ReleaseNote[] = [
   {
+    version: '4.7.2',
+    date: '2026-07-30',
+    title: 'Ausgerichtete Dashboard-Aktionen',
+    sections: [
+      {
+        heading: 'Verbesserungen',
+        items: [
+          'Die Breite des Schnellzugriff-Bereichs entspricht auf breiten Desktop-Ansichten nun der Karte für die Monatssumme',
+          'Die Tabelle der anstehenden Rechnungen nutzt den verbleibenden Platz, während das Verhalten auf Tablets und Mobilgeräten erhalten bleibt',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.7.1',
     date: '2026-07-30',
     title: 'Kompaktes responsives Layout',

--- a/apps/web/src/config/releaseNotes.ts
+++ b/apps/web/src/config/releaseNotes.ts
@@ -50,6 +50,20 @@ export interface ReleaseNote {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '4.7.2',
+    date: '2026-07-30',
+    title: 'Aligned Dashboard Actions',
+    sections: [
+      {
+        heading: 'Improvements',
+        items: [
+          'Matched the Quick Actions panel width to the Monthly Total card on wide desktop layouts',
+          'Gave the Upcoming Bills table the remaining horizontal space while preserving tablet and mobile stacking behavior',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.7.1',
     date: '2026-07-30',
     title: 'Compact Responsive Layout',

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -88,7 +88,7 @@ export function Dashboard({
 
       {/* Content Grid */}
       <Grid gap="sm">
-        <Grid.Col span={{ base: 12, md: 8 }}>
+        <Grid.Col span={{ base: 12, md: 8, lg: 9 }}>
           {/* Upcoming Bills */}
           <UpcomingBillsList
             bills={bills}
@@ -98,7 +98,7 @@ export function Dashboard({
             onViewAll={onViewBills}
           />
         </Grid.Col>
-        <Grid.Col span={{ base: 12, md: 4 }}>
+        <Grid.Col span={{ base: 12, md: 4, lg: 3 }}>
           {/* Quick Actions */}
           <Paper withBorder p="md" radius="md">
             <Title order={5} mb="md">{t('dashboardPage.quickActions')}</Title>


### PR DESCRIPTION
## What changed

- Match the Quick Actions panel to the Monthly Total card's quarter-width desktop column
- Expand Upcoming Bills to the remaining three-quarter desktop width
- Keep the existing one-third action column on tablets and full-width stacking on phones
- Bump packaged application and release-note versions to 4.7.2

## Why

Quick Actions used a 4/12 grid span while Monthly Total occupied one of four equal stat-card columns. At wide desktop widths this made Quick Actions visibly wider than the card above it.

## Validation

- Rendered Playwright QA at 1311×668: both panels measured exactly 249.75px
- Rendered Playwright QA at 390×844: document width remained 390px
- Quick Actions “View All Bills” interaction navigated to /bills
- Browser console/network errors: none
- Web tests: 60 passed
- Web lint: 0 errors (4 unchanged hook-dependency warnings)
- Production web build: passed
- Backend self-hosted and SaaS suites: passed
- SaaS backend result: 303 passed, 3 skipped