### PR TITLE
Release BillManager v4.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ A **secure multi-user** web application for tracking recurring expenses and inco
 
 ---
 
-## 🎉 What's New in v4.7.2
+## 🎉 What's New in v4.7.3
 
-**Aligned Dashboard Actions** - The Quick Actions panel now matches the Monthly Total card width on wide desktop layouts.
+**Zero-Value Payments** - Record a payment of zero when no balance is due while still advancing the bill and preserving payment history.
 
 ### Highlights
 
-- **Consistent Columns** - Quick Actions uses the same quarter-width dashboard column as Monthly Total
-- **More Bill Space** - Upcoming Bills gains the remaining desktop width for clearer table content
-- **Responsive Balance** - Tablet layouts retain the roomier one-third action column
-- **No Mobile Regression** - Phone layouts continue stacking panels at full width
+- **Advance Without a Balance** - Zero-value payments can move recurring bills to their next due date
+- **Accurate Averages** - Zero-value occurrences are included in variable-bill payment averages
+- **Web and Mobile Support** - Create and edit zero-value payments from either client
+- **Input Safety Preserved** - Negative, malformed, and currency-invalid amounts remain rejected
 
 ---
 

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-alpha.1",
       "dependencies": {
         "@expo/metro-runtime": "~57.0.8",
-        "@expo/ui": "~57.0.8",
+        "@expo/ui": "~57.0.9",
         "@expo/vector-icons": "^15.0.2",
         "@react-native-community/datetimepicker": "9.1.0",
         "@react-native-community/netinfo": "12.0.1",
@@ -22,30 +22,30 @@
         "axios": "^1.19.0",
         "babel-preset-expo": "~57.0.3",
         "date-fns": "^4.4.0",
-        "expo": "~57.0.9",
-        "expo-auth-session": "~57.0.5",
-        "expo-background-task": "~57.0.7",
-        "expo-build-properties": "~57.0.8",
+        "expo": "~57.0.11",
+        "expo-auth-session": "~57.0.6",
+        "expo-background-task": "~57.0.8",
+        "expo-build-properties": "~57.0.9",
         "expo-constants": "~57.0.5",
         "expo-crypto": "~57.0.1",
         "expo-dev-client": "~57.0.10",
         "expo-file-system": "~57.0.1",
         "expo-font": "~57.0.1",
         "expo-haptics": "~57.0.1",
-        "expo-linking": "~57.0.4",
+        "expo-linking": "~57.0.5",
         "expo-local-authentication": "~57.0.2",
         "expo-localization": "~57.0.1",
-        "expo-notifications": "~57.0.8",
+        "expo-notifications": "~57.0.9",
         "expo-print": "~57.0.1",
         "expo-secure-store": "~57.0.1",
-        "expo-sharing": "~57.0.8",
+        "expo-sharing": "~57.0.9",
         "expo-splash-screen": "~57.0.5",
         "expo-sqlite": "~57.0.1",
         "expo-status-bar": "~57.0.1",
-        "expo-symbols": "~57.0.1",
+        "expo-symbols": "~57.0.2",
         "expo-system-ui": "~57.0.2",
-        "expo-task-manager": "~57.0.7",
-        "expo-updates": "~57.0.11",
+        "expo-task-manager": "~57.0.8",
+        "expo-updates": "~57.0.12",
         "expo-web-browser": "~57.0.2",
         "expo-widgets": "~57.0.6",
         "i18next": "^26.3.6",
@@ -1413,9 +1413,9 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.6.tgz",
-      "integrity": "sha512-7CmKrS5Rnu8aSZyNlxH2qzA7Ls1HEa4EQvEVOAkHDKPr1e4Cg/nz7I7dUl09QDTVjMvkKYDH4Th0DuAsgqASaw==",
+      "version": "57.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.7.tgz",
+      "integrity": "sha512-jvXMiNuH8W7fmU9yCk4/jVwDX2G/5rWUg5PZ22mriccEeQVS9HJjQiUHivMaK6MxEG5L9f0RPScxe/nQfnpQvg==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^57.0.2",
@@ -1858,9 +1858,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/ui": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/ui/-/ui-57.0.8.tgz",
-      "integrity": "sha512-aR17CRM45k4JyFahX4Xn2b6ti3aiddC4SAzvsm3iUCVacQA6tGmClu012rYNeVXhJ96csX2o7EEymfzYqgJNxw==",
+      "version": "57.0.9",
+      "resolved": "https://registry.npmjs.org/@expo/ui/-/ui-57.0.9.tgz",
+      "integrity": "sha512-VIxvk5ncgylBj2vrIP1iLaMc3XmYucKbf0hIcg3qx9l2anB9JzaYnH7cvVgNU3RfwV8R9m/tA7lX9BP7D8uMQw==",
       "license": "MIT",
       "dependencies": {
         "sf-symbols-typescript": "^2.1.0",
@@ -3783,9 +3783,9 @@
       }
     },
     "node_modules/agent-cli-detector": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/agent-cli-detector/-/agent-cli-detector-0.1.4.tgz",
-      "integrity": "sha512-qPgevFvpaQoBaRJVKzr8R7h1WPvV3DtbgRIQlne4le66KBzXx5hNBwo/+NTw67LgkKBlhCzksrdautpUdlls0Q==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/agent-cli-detector/-/agent-cli-detector-0.1.5.tgz",
+      "integrity": "sha512-6xvLw0EGPuxoYGZeqyMV4AK+WoZ31jsqb7a5pln1BTf6oDFsrgvfCJT7E7y9oAqifJZhJ3fZ0J36H7o6JzrB0Q==",
       "license": "MIT",
       "bin": {
         "agent-cli-detector": "dist/cli.js"
@@ -4005,9 +4005,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "57.0.5",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-57.0.5.tgz",
-      "integrity": "sha512-sz9ZBTiUAlu5P9VORVNKoeAaY2qKFQRC6eQV5Y8aMkqcorvXKEv97UeCkFMLmMBEPKA+QeWImREKkX9/H21WQA==",
+      "version": "57.0.6",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-57.0.6.tgz",
+      "integrity": "sha512-ASyy0iP7yPQtq2QaMEnZG4O7YQ/x4sTMguk7PZcow2OHFnWsBpX6v+UCmh/uwCzGfD1q93jDQEuACWwWx4kSrw==",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.20.5",
@@ -4056,7 +4056,7 @@
       "peerDependencies": {
         "@babel/runtime": "^7.20.0",
         "expo": "*",
-        "expo-widgets": "^57.0.7",
+        "expo-widgets": "^57.0.8",
         "react-refresh": ">=0.14.0 <1.0.0"
       },
       "peerDependenciesMeta": {
@@ -5397,15 +5397,15 @@
       }
     },
     "node_modules/expo": {
-      "version": "57.0.9",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-57.0.9.tgz",
-      "integrity": "sha512-NDEvnU+vjRdMbtOyDC25OSok9/E97al97pyx+bMphQgNRGAED0D7oF8ha7oGYsLE+7jFzpPADVM9S60dGbpHIA==",
+      "version": "57.0.11",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-57.0.11.tgz",
+      "integrity": "sha512-R97257N39Dw0kQFuI4/RvYx95GQ+dmePdo8hxcMOjDxAT4VcCckjILJeAWCE19Jxjb92hZ5NDXAfDPkkV1RB9w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "^57.0.11",
+        "@expo/cli": "^57.0.13",
         "@expo/config": "~57.0.6",
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/config-plugins": "~57.0.7",
         "@expo/devtools": "~57.0.1",
         "@expo/dom-webview": "~57.0.1",
         "@expo/fingerprint": "^0.20.6",
@@ -5414,14 +5414,14 @@
         "@expo/metro": "~56.0.0",
         "@expo/metro-config": "~57.0.7",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~57.0.5",
-        "expo-asset": "~57.0.8",
-        "expo-constants": "~57.0.8",
-        "expo-file-system": "~57.0.1",
+        "babel-preset-expo": "~57.0.6",
+        "expo-asset": "~57.0.9",
+        "expo-constants": "~57.0.9",
+        "expo-file-system": "~57.0.2",
         "expo-font": "~57.0.1",
         "expo-keep-awake": "~57.0.1",
         "expo-modules-autolinking": "~57.0.9",
-        "expo-modules-core": "~57.0.8",
+        "expo-modules-core": "~57.0.10",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-minimum": "^0.1.2"
@@ -5468,13 +5468,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-57.0.8.tgz",
-      "integrity": "sha512-sGocG+Wd2WcZ1KjKyB2LfUZXzrBM0VHEATGcpJKF9T3HM56M/sMbH73vv+n85u5Zr0FkJjEbV1DWhGPimCR1QQ==",
+      "version": "57.0.9",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-57.0.9.tgz",
+      "integrity": "sha512-FXlwwW5ThJ2kwXqVX0VcYcDrbmzPDUGPYJOuQZYfsdVB+TLA8LmOgU0Y5ykzLmLs5ONiqs/YjT6Uubv1NUQFzg==",
       "license": "MIT",
       "dependencies": {
         "@expo/image-utils": "^0.11.4",
-        "expo-constants": "~57.0.8"
+        "expo-constants": "~57.0.9"
       },
       "peerDependencies": {
         "expo": "*",
@@ -5483,15 +5483,15 @@
       }
     },
     "node_modules/expo-auth-session": {
-      "version": "57.0.5",
-      "resolved": "https://registry.npmjs.org/expo-auth-session/-/expo-auth-session-57.0.5.tgz",
-      "integrity": "sha512-4u/CIMCrQ88QO9AKSaw61Vva+Gmtil254xBjDB2SuAeyN/I9mNxZKkG0xtcm3iDSmJFMuHkYDKNo3RvTn3sz+Q==",
+      "version": "57.0.6",
+      "resolved": "https://registry.npmjs.org/expo-auth-session/-/expo-auth-session-57.0.6.tgz",
+      "integrity": "sha512-HRUAzGgWQjfPd+jdd0jbVHm+0QQE6KjVyXXe+rKJ+Ozqne1ub/Str8COVnJ6wZFI9ASuyQiI5G3hAMNd2yr1CQ==",
       "license": "MIT",
       "dependencies": {
         "expo-application": "~57.0.2",
-        "expo-constants": "~57.0.7",
+        "expo-constants": "~57.0.9",
         "expo-crypto": "~57.0.1",
-        "expo-linking": "~57.0.4",
+        "expo-linking": "~57.0.5",
         "expo-web-browser": "~57.0.2",
         "invariant": "^2.2.4"
       },
@@ -5501,21 +5501,21 @@
       }
     },
     "node_modules/expo-background-task": {
-      "version": "57.0.7",
-      "resolved": "https://registry.npmjs.org/expo-background-task/-/expo-background-task-57.0.7.tgz",
-      "integrity": "sha512-fFcms4qQ0mw5XYjG+zbbmaER8pyxIhqEVIbOiBUfWofR1kUj4mQfwkMjJzlWGXN7nCg0vRBUpDk1oJCR0mts6g==",
+      "version": "57.0.8",
+      "resolved": "https://registry.npmjs.org/expo-background-task/-/expo-background-task-57.0.8.tgz",
+      "integrity": "sha512-W+bkvXm4uJ0HCvgrkHgIVU1C10sMHEkUblyN2Bx3YW7DXTbs3osnSQHMoC1cOq4OKDodjwp3zkqMatMwlUNZIQ==",
       "license": "MIT",
       "dependencies": {
-        "expo-task-manager": "~57.0.7"
+        "expo-task-manager": "~57.0.8"
       },
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-build-properties": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-57.0.8.tgz",
-      "integrity": "sha512-6/SDeqKLKaF8MRfLZ3JhiiDN0y5uXtyefhWRZ42ZX03QVZ8Fw4dnbdTSHpsBvbKNIluYk5bP/zosdwkbeeNd9A==",
+      "version": "57.0.9",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-57.0.9.tgz",
+      "integrity": "sha512-IX8Nz85yNDZyqBK7zbLEfn4ijMGaF6TmLjCY2KE0UKltUoV78DhgN6ksPZbDbPDvqLpU2fMY/5OD4CbYB7hHwg==",
       "license": "MIT",
       "dependencies": {
         "@expo/schema-utils": "^57.0.2",
@@ -5539,9 +5539,9 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-57.0.8.tgz",
-      "integrity": "sha512-ts+B7E5076BtkblrKGy7+Sm/R2obHfTwqhmYQVYbWRtilv3+C/xNwHZhyNEnAvzM/JjKqx7UdaITUBYaeFreZw==",
+      "version": "57.0.9",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-57.0.9.tgz",
+      "integrity": "sha512-Y47sGiF+U8fwicUSPdJPjB27PuU+FgLK4Mpai0ksZF5hv8jNN3HBqKuDNxsiu70uHBKf80TaR4gwMPh0pmETiQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "~2.4.2"
@@ -5620,9 +5620,9 @@
       "license": "MIT"
     },
     "node_modules/expo-file-system": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-57.0.1.tgz",
-      "integrity": "sha512-w7/ERvQFrGP2apTO9lDtZ+O6JQIhfakL7+Xqzh+rfMO9B4LB4qwrz+YvLgir8KFRVX64JHBnRuYBVLY1oQZcqw==",
+      "version": "57.0.2",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-57.0.2.tgz",
+      "integrity": "sha512-bPgzpaOJ3NWHZxV++Osj/1QoFzFe/QOo1jBF4EODJdiZgrrxyi2dv+7PLhKuut5QqPBuihUOITRh3s5jhRtA5A==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -5669,12 +5669,12 @@
       }
     },
     "node_modules/expo-linking": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-57.0.4.tgz",
-      "integrity": "sha512-e1alfHNJdywIfJkCuKMc6M3hBfAGPd2gKMeF/6V7qwFWzHCS2mTBqU+KaO4FLpltA5Nt6CYEx6zmUlGfUF+8lA==",
+      "version": "57.0.5",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-57.0.5.tgz",
+      "integrity": "sha512-SmJI3wr0EVfeKPGf+Qgr9gUbrXk8mM0ATqYLvAX/EAzawDjohPzMJ5pTt7TYMX0Wknj4XCtyCQrGhnERMXT6cQ==",
       "license": "MIT",
       "dependencies": {
-        "expo-constants": "~57.0.7",
+        "expo-constants": "~57.0.9",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
@@ -5735,9 +5735,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-57.0.8.tgz",
-      "integrity": "sha512-ZUU943Oso3B8jFggC+2+LOk8oa+im66IQlleYay6WP5iexbdF2fqpgC4BcYsN4xhCkDKh7KDINSt1FlcxyRRjQ==",
+      "version": "57.0.10",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-57.0.10.tgz",
+      "integrity": "sha512-aRi3G8OctoyZl8x9CLTVpbPljClfKm2eqKRgBzhcGsrH3gS1t5Y2ye7+PIZK4XK2VVP5iGqygN2b1vtqRo3xVQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/expo-modules-macros-plugin": "0.6.1",
@@ -5765,16 +5765,16 @@
       }
     },
     "node_modules/expo-notifications": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-57.0.8.tgz",
-      "integrity": "sha512-9pTNFMB9vk7MmULRSq7SD2nBRXhIh7IYAOSAFzFIYna6csJKdzeuKikjuUwP5KZYwxejoaN2BYBBqdLKaUpT/w==",
+      "version": "57.0.9",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-57.0.9.tgz",
+      "integrity": "sha512-AeA4sdgvfeyw5/O+JPekCIex8JfoBO21fABfZCKAeXF19pWaVtXva08dqwF41JW/LWAmvrshCAH36gP+jdVD4Q==",
       "license": "MIT",
       "dependencies": {
         "@expo/image-utils": "^0.11.4",
         "abort-controller": "^3.0.0",
         "badgin": "^1.1.5",
         "expo-application": "~57.0.2",
-        "expo-constants": "~57.0.8"
+        "expo-constants": "~57.0.9"
       },
       "peerDependencies": {
         "expo": "*",
@@ -5811,12 +5811,12 @@
       }
     },
     "node_modules/expo-sharing": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-57.0.8.tgz",
-      "integrity": "sha512-ZjiA09iJjzveachyBlbIijSH++fiacdvuenxb/gsdW21V3SUSxMQd+krPmafnhnMus5aBqpP0TXCBfBJN+0Bfg==",
+      "version": "57.0.9",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-57.0.9.tgz",
+      "integrity": "sha512-zcN1D3RzOZk967s233EeES/hOmRTNRd/7OTXsYQniuXKplv6EgCTjvn+YE7BPVoExz8Ve4a8hLma4Btr1UwZgw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "^57.0.6",
+        "@expo/config-plugins": "^57.0.7",
         "@expo/config-types": "^57.0.2",
         "@expo/plist": "^0.8.1"
       },
@@ -5872,9 +5872,9 @@
       "license": "MIT"
     },
     "node_modules/expo-symbols": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/expo-symbols/-/expo-symbols-57.0.1.tgz",
-      "integrity": "sha512-8Zf+a83OywV0vf1NUtSKpNqKcULmO0GTI+zfFnGYl7SLDH9FjL5RcEZoy6CHvCgq2KDrQF21pl3r7Tb4ItPscw==",
+      "version": "57.0.2",
+      "resolved": "https://registry.npmjs.org/expo-symbols/-/expo-symbols-57.0.2.tgz",
+      "integrity": "sha512-qZ0iqOflm5lZGwRsQ5Y8sDksw3GAUKwHSX1bJBoocXf7gu14vafIXXYWte+JT9VfXAUGyKodJhLHP/GoOrcNWg==",
       "license": "MIT",
       "dependencies": {
         "@expo-google-fonts/material-symbols": "^0.4.1",
@@ -5908,9 +5908,9 @@
       }
     },
     "node_modules/expo-task-manager": {
-      "version": "57.0.7",
-      "resolved": "https://registry.npmjs.org/expo-task-manager/-/expo-task-manager-57.0.7.tgz",
-      "integrity": "sha512-ePnBVrkntuxV0XPKhMlJoMyqMH4K3OGrUfqajf/3UzVjfTB2ARmR3ExtB996EAtrsAQ8fREvZrdhbBAnDSiRAg==",
+      "version": "57.0.8",
+      "resolved": "https://registry.npmjs.org/expo-task-manager/-/expo-task-manager-57.0.8.tgz",
+      "integrity": "sha512-YLTU27QeDEGWA2s71fVevovI9Y1iXnQTypisOGQBmOyPUwKITz4jvBJpye7HCxblKbG3pOkK48SI/YsZdyyUiQ==",
       "license": "MIT",
       "dependencies": {
         "unimodules-app-loader": "~57.0.1"
@@ -5921,9 +5921,9 @@
       }
     },
     "node_modules/expo-updates": {
-      "version": "57.0.11",
-      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-57.0.11.tgz",
-      "integrity": "sha512-V8m+bVHvyUXggjmhxt/t4yyj6oDfdAN0kdx0nAt9p2i7xGci6lkzfWzcwsNUE0ZmStHR4ZyzQVFR1U0vP7C/7g==",
+      "version": "57.0.12",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-57.0.12.tgz",
+      "integrity": "sha512-ZFsW8Mi9qFrrYPSXF++1FXejjflRdgbVPzaSJJATuHelVmIIb3D98gCO9sIsaLPHO1RCQVj1ltkj51VnwVL+4g==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
@@ -5983,13 +5983,13 @@
       }
     },
     "node_modules/expo-widgets": {
-      "version": "57.0.7",
-      "resolved": "https://registry.npmjs.org/expo-widgets/-/expo-widgets-57.0.7.tgz",
-      "integrity": "sha512-3CZHG4+/UOrwBZF+TrN1DhV+W4llZ2KvvnsWfsguimEyfL8uo73dNmFZ8r23p5mMmH2rAuJ0hzoS2ubQtxzV6A==",
+      "version": "57.0.8",
+      "resolved": "https://registry.npmjs.org/expo-widgets/-/expo-widgets-57.0.8.tgz",
+      "integrity": "sha512-D5pSnmz48/AEYFfZAQuy+TS+HwkXxj0RB10n0jeORMc4gPM9LKqj0hWt1xCYZ6PpuyJ4QS8hrXSKLK8kXphWPg==",
       "license": "MIT",
       "dependencies": {
         "@expo/plist": "^0.8.1",
-        "@expo/ui": "~57.0.8"
+        "@expo/ui": "~57.0.9"
       },
       "peerDependencies": {
         "expo": "*",
@@ -5998,14 +5998,14 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "57.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-57.0.11.tgz",
-      "integrity": "sha512-ENXCwRyL8Q9qbabUmm0L6w9kXTmdGotW7eDEEWmUDXLPux+nEzNDqw0MzWQ5K3ZsXS51QmUJZg5yETB+6SnNRg==",
+      "version": "57.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-57.0.13.tgz",
+      "integrity": "sha512-8gjLMyx+s0dLeDHlcfjM9D9x5yrCU5C6516rmC7q/Wiyuj1fxgr/cbDSmjdpQKkjlvvfvNwtRyMk2zhvhPohiw==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
         "@expo/config": "~57.0.6",
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/config-plugins": "~57.0.7",
         "@expo/devcert": "^1.2.1",
         "@expo/env": "~2.4.2",
         "@expo/image-utils": "^0.11.4",
@@ -6020,7 +6020,7 @@
         "@expo/plist": "^0.8.1",
         "@expo/prebuild-config": "^57.0.10",
         "@expo/require-utils": "^57.0.4",
-        "@expo/router-server": "^57.0.4",
+        "@expo/router-server": "^57.0.5",
         "@expo/schema-utils": "^57.0.2",
         "@expo/spawn-async": "^1.8.0",
         "@expo/ws-tunnel": "^2.0.0",
@@ -6080,17 +6080,17 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/router-server": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-57.0.4.tgz",
-      "integrity": "sha512-ucqCP0hK8nZb9+S8QJYdQxNCkfRClzkKdg2RpWYDKDYgRIHyoRyxEDRgDgvbhH+q78yfY83abU8OTx8MMOrf1g==",
+      "version": "57.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-57.0.5.tgz",
+      "integrity": "sha512-vke39l0bo3H2q9JB/KXpAJ7HpscdTG3Mktbxanc8yn3riWzzSsnv0uxwZGZCrZrnDQzFxlLTXgbZrGkU26ng1w==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
       "peerDependencies": {
-        "@expo/metro-runtime": "^57.0.7",
+        "@expo/metro-runtime": "^57.0.8",
         "expo": "*",
-        "expo-constants": "^57.0.7",
+        "expo-constants": "^57.0.9",
         "expo-font": "^57.0.1",
         "expo-router": "*",
         "expo-server": "^57.0.1",
@@ -6181,9 +6181,9 @@
       }
     },
     "node_modules/expo/node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -8163,9 +8163,9 @@
       "license": "MIT"
     },
     "node_modules/multitars": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/multitars/-/multitars-1.0.0.tgz",
-      "integrity": "sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multitars/-/multitars-1.0.1.tgz",
+      "integrity": "sha512-Do9rHaSDfQ2Fk5Dpg2RjQ4M48Ol7rSq1gvKn/dXJYnhKEm8RRjjUvyiGDDEhJqb0hJPGjRaTB1kx6beqKO/i6Q==",
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -2,6 +2,13 @@
   "name": "@billmanager/mobile",
   "version": "1.0.0-alpha.1",
   "main": "index.ts",
+  "expo": {
+    "install": {
+      "exclude": [
+        "expo-sharing"
+      ]
+    }
+  },
   "engines": {
     "node": ">=24.18.0 <25"
   },
@@ -36,7 +43,7 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~57.0.8",
-    "@expo/ui": "~57.0.8",
+    "@expo/ui": "~57.0.9",
     "@expo/vector-icons": "^15.0.2",
     "@react-native-community/datetimepicker": "9.1.0",
     "@react-native-community/netinfo": "12.0.1",
@@ -49,30 +56,30 @@
     "axios": "^1.19.0",
     "babel-preset-expo": "~57.0.3",
     "date-fns": "^4.4.0",
-    "expo": "~57.0.9",
-    "expo-auth-session": "~57.0.5",
-    "expo-background-task": "~57.0.7",
-    "expo-build-properties": "~57.0.8",
+    "expo": "~57.0.11",
+    "expo-auth-session": "~57.0.6",
+    "expo-background-task": "~57.0.8",
+    "expo-build-properties": "~57.0.9",
     "expo-constants": "~57.0.5",
     "expo-crypto": "~57.0.1",
     "expo-dev-client": "~57.0.10",
     "expo-file-system": "~57.0.1",
     "expo-font": "~57.0.1",
     "expo-haptics": "~57.0.1",
-    "expo-linking": "~57.0.4",
+    "expo-linking": "~57.0.5",
     "expo-local-authentication": "~57.0.2",
     "expo-localization": "~57.0.1",
-    "expo-notifications": "~57.0.8",
+    "expo-notifications": "~57.0.9",
     "expo-print": "~57.0.1",
     "expo-secure-store": "~57.0.1",
-    "expo-sharing": "~57.0.8",
+    "expo-sharing": "~57.0.9",
     "expo-splash-screen": "~57.0.5",
     "expo-sqlite": "~57.0.1",
     "expo-status-bar": "~57.0.1",
-    "expo-symbols": "~57.0.1",
+    "expo-symbols": "~57.0.2",
     "expo-system-ui": "~57.0.2",
-    "expo-task-manager": "~57.0.7",
-    "expo-updates": "~57.0.11",
+    "expo-task-manager": "~57.0.8",
+    "expo-updates": "~57.0.12",
     "expo-web-browser": "~57.0.2",
     "expo-widgets": "~57.0.6",
     "i18next": "^26.3.6",

--- a/apps/mobile/src/i18n/moneyInputConsumers.test.ts
+++ b/apps/mobile/src/i18n/moneyInputConsumers.test.ts
@@ -16,6 +16,8 @@ describe('mobile money input consumers', () => {
     expect(addBill).toContain('{...moneyInputProps}');
     expect(billDetail).toContain('parseMoneyInput(payAmount)');
     expect(billDetail).toContain('parseMoneyInput(editAmount)');
+    expect(billDetail).not.toContain('amount <= 0');
+    expect(billDetail.match(/amount < 0/g)).toHaveLength(2);
     expect(billDetail.match(/\{\.\.\.moneyInputProps\}/g)).toHaveLength(2);
     expect(addBill).not.toContain('placeholder="0.00"');
     expect(billDetail).not.toContain('placeholder="0.00"');

--- a/apps/mobile/src/screens/BillDetailScreen.tsx
+++ b/apps/mobile/src/screens/BillDetailScreen.tsx
@@ -81,7 +81,7 @@ export default function BillDetailScreen({ route, navigation }: Props) {
     if (!bill) return;
 
     const amount = parseMoneyInput(payAmount);
-    if (amount === null || amount <= 0) {
+    if (amount === null || amount < 0) {
       Alert.alert(t('mobileParity.payments.checkDetails'), t('mobileParity.billDetail.invalidAmount'));
       return;
     }
@@ -204,7 +204,7 @@ export default function BillDetailScreen({ route, navigation }: Props) {
     if (!editPayment) return;
 
     const amount = parseMoneyInput(editAmount);
-    if (amount === null || amount <= 0) {
+    if (amount === null || amount < 0) {
       Alert.alert(t('mobileParity.payments.checkDetails'), t('mobileParity.billDetail.invalidAmount'));
       return;
     }

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -29,7 +29,7 @@ JWT_SECRET_KEY=change-this-to-another-random-64-char-string
 # Version values exposed by the pre-auth mobile compatibility contract.
 # APP_VERSION normally matches the deployed release/image tag.
 # Leave MINIMUM_MOBILE_VERSION empty unless older mobile binaries must be blocked.
-# APP_VERSION=4.7.2
+# APP_VERSION=4.7.3
 # MINIMUM_MOBILE_VERSION=
 
 # =============================================================================

--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -3129,7 +3129,9 @@ def jwt_pay_bill(bill_id):
         return conflict
 
     payment_amount = data.get("amount", bill.amount)
-    is_valid, error = validate_amount(payment_amount, currency=_current_user_currency())
+    is_valid, error = validate_amount(
+        payment_amount, allow_zero=True, currency=_current_user_currency()
+    )
     if not is_valid:
         return jsonify({"success": False, "error": error}), 400
 
@@ -3414,7 +3416,9 @@ def jwt_update_payment(payment_id):
         return conflict
 
     if "amount" in data:
-        is_valid, error = validate_amount(data["amount"], currency=_current_user_currency())
+        is_valid, error = validate_amount(
+            data["amount"], allow_zero=True, currency=_current_user_currency()
+        )
         if not is_valid:
             return jsonify({"success": False, "error": error}), 400
         payment.amount = data["amount"]

--- a/apps/server/config.py
+++ b/apps/server/config.py
@@ -307,7 +307,7 @@ DEFAULT_LOCALE = os.environ.get("DEFAULT_LOCALE", "en-US")
 # version: it only changes when a mobile client must handle a breaking contract
 # change. An unset minimum version means that any client implementing the
 # advertised contract is accepted.
-SERVER_VERSION = os.environ.get("APP_VERSION", "4.7.2")
+SERVER_VERSION = os.environ.get("APP_VERSION", "4.7.3")
 MOBILE_CONTRACT_VERSION = 1
 MINIMUM_MOBILE_VERSION = os.environ.get("MINIMUM_MOBILE_VERSION") or None
 

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -14,7 +14,7 @@ info:
 
     Access tokens expire after 15 minutes. Refresh tokens expire after 7 days.
 
-  version: 4.7.2
+  version: 4.7.3
   license:
     name: O'Saasy License
     url: https://osaasy.dev/
@@ -3910,6 +3910,7 @@ components:
           properties:
             amount:
               type: number
+              minimum: 0
               description: Payment amount (defaults to bill amount)
             payment_date:
               type: string
@@ -3930,6 +3931,7 @@ components:
           properties:
             amount:
               type: number
+              minimum: 0
             payment_date:
               type: string
               format: date

--- a/apps/server/tests/test_payments.py
+++ b/apps/server/tests/test_payments.py
@@ -109,6 +109,42 @@ class TestPaymentsCRUD:
 class TestPaymentValidation:
     """Test payment input validation."""
 
+    def test_zero_payment_advances_due_date_and_counts_toward_average(
+        self, client, auth_headers_with_db, test_bill, db_session
+    ):
+        """A zero payment is still a real occurrence for variable bills."""
+        test_bill.is_variable = True
+        test_bill.amount = None
+        db_session.add(
+            Payment(
+                bill_id=test_bill.id,
+                amount=100,
+                payment_date='2024-12-15',
+            )
+        )
+        db_session.commit()
+
+        response = client.post(
+            f'/api/v2/bills/{test_bill.id}/pay',
+            headers=auth_headers_with_db,
+            json={
+                'amount': 0,
+                'payment_date': '2025-01-15',
+                'advance_due': True,
+            },
+        )
+
+        assert response.status_code == 200
+        db_session.refresh(test_bill)
+        assert test_bill.due_date == '2025-02-15'
+        assert Payment.query.filter_by(bill_id=test_bill.id, amount=0).count() == 1
+
+        bill_response = client.get(
+            f'/api/v2/bills/{test_bill.id}', headers=auth_headers_with_db
+        )
+        assert bill_response.status_code == 200
+        assert bill_response.get_json()['data']['avg_amount'] == 50
+
     def test_payment_defaults_to_bill_amount(self, client, auth_headers_with_db, test_bill):
         """Test that payments default to bill amount when not specified."""
         response = client.post(f'/api/v2/bills/{test_bill.id}/pay',
@@ -174,6 +210,27 @@ class TestPaymentValidation:
         )
 
         assert response.status_code == 400
+
+    def test_payment_update_allows_zero(
+        self, client, auth_headers_with_db, test_bill, db_session
+    ):
+        payment = Payment(
+            bill_id=test_bill.id,
+            amount=100,
+            payment_date='2026-08-15',
+        )
+        db_session.add(payment)
+        db_session.commit()
+
+        response = client.put(
+            f'/api/v2/payments/{payment.id}',
+            headers=auth_headers_with_db,
+            json={'amount': 0},
+        )
+
+        assert response.status_code == 200
+        db_session.refresh(payment)
+        assert payment.amount == 0
 
 
 class TestPaymentAuthorization:

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "4.7.2",
+      "version": "4.7.3",
       "dependencies": {
         "@mantine/charts": "^9.5.0",
         "@mantine/core": "^9.5.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "4.7.2",
+  "version": "4.7.3",
   "type": "module",
   "engines": {
     "node": ">=24.18.0 <25"

--- a/apps/web/src/config/releaseNotes.de.ts
+++ b/apps/web/src/config/releaseNotes.de.ts
@@ -2,6 +2,21 @@ import type { ReleaseNote } from './releaseNotes';
 
 export const germanReleaseNotes: ReleaseNote[] = [
   {
+    version: '4.7.3',
+    date: '2026-08-06',
+    title: 'Zahlungen mit Nullbetrag',
+    sections: [
+      {
+        heading: 'Fehlerbehebungen',
+        items: [
+          'Zahlungen mit Nullbetrag können wiederkehrende Rechnungen weiterstellen, wenn kein Betrag fällig ist',
+          'Zahlungen mit Nullbetrag werden in Durchschnittswerten variabler Rechnungen berücksichtigt; negative und ungültige Beträge bleiben gesperrt',
+          'Die mobile App verwendet nun die neuesten veröffentlichten Patch-Abhängigkeiten für Expo SDK 57',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.7.2',
     date: '2026-07-30',
     title: 'Ausgerichtete Dashboard-Aktionen',

--- a/apps/web/src/config/releaseNotes.ts
+++ b/apps/web/src/config/releaseNotes.ts
@@ -50,6 +50,21 @@ export interface ReleaseNote {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '4.7.3',
+    date: '2026-08-06',
+    title: 'Zero-Value Payments',
+    sections: [
+      {
+        heading: 'Fixes',
+        items: [
+          'Allowed zero-value payments to advance recurring bills when no balance is due',
+          'Included zero-value payment occurrences in variable-bill averages while continuing to reject negative and invalid amounts',
+          'Aligned the mobile app with the latest published Expo SDK 57 patch dependencies',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.7.2',
     date: '2026-07-30',
     title: 'Aligned Dashboard Actions',


### PR DESCRIPTION
## What changed

- allow zero-value payments through the API and mobile create/edit flows
- keep negative, malformed, and currency-invalid payment amounts rejected
- document zero as the payment minimum in OpenAPI
- prove zero payments advance recurring due dates and count in variable-bill averages
- package the change as BillManager 4.7.3 with localized release notes
- align mobile dependencies with published Expo SDK 57 patches; exclude expo-sharing from version validation because Expo currently requests unpublished 57.0.10 while 57.0.9 is the latest available release

## Root cause

The currency validation introduced for 4.6.x used the general positive-amount default for payment create and update endpoints. Mobile duplicated the same strict-positive check. The web form already allowed zero, but the API rejected the request.

## Validation

- backend: 305 passed, 3 skipped in self-hosted mode
- payment regression suite: 14 passed
- web: 60 tests passed, lint completed with four existing warnings, production build passed
- mobile: 225 tests passed; i18n, OpenAPI, lint, typecheck, Maestro, transport profile, Expo compatibility, and Expo Doctor 20/20 passed
- web and mobile npm audits: zero vulnerabilities
