### PR TITLE
chore: release runtime modernization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ A **secure multi-user** web application for tracking recurring expenses and inco
 
 ---
 
-## 🎉 What's New in v4.8.0
+## 🎉 What's New in v4.9.0
 
-**Dependency Security Baseline** - The supported web, mobile, Python, and container toolchains have been validated against their current secure release lines.
+**Runtime Modernization** - Production and development builds now use the supported Node 24 LTS and Python 3.14 runtime baseline.
 
 ### Highlights
 
-- **Current Secure Libraries** - The web and Python dependency audits complete without known vulnerabilities
-- **Supported Toolchains** - Node 24 LTS, Expo SDK 57, React Native 0.86, Mantine 9, and Vite 8 remain the validated build baseline
+- **Current Runtimes** - Node 24 LTS and Python 3.14 are the supported container and CI baseline
+- **Consistent Builds** - Engine constraints prevent accidental builds with unsupported Node releases
 - **Release Verification** - Backend, web, mobile, security, and multi-architecture container checks gate published images
 
 ---

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -29,7 +29,7 @@ JWT_SECRET_KEY=
 # Version values exposed by the pre-auth mobile compatibility contract.
 # APP_VERSION normally matches the deployed release/image tag.
 # Leave MINIMUM_MOBILE_VERSION empty unless older mobile binaries must be blocked.
-# APP_VERSION=4.7.6
+# APP_VERSION=4.9.0
 # MINIMUM_MOBILE_VERSION=
 
 # =============================================================================

--- a/apps/server/config.py
+++ b/apps/server/config.py
@@ -315,7 +315,7 @@ DEFAULT_LOCALE = os.environ.get("DEFAULT_LOCALE", "en-US")
 # version: it only changes when a mobile client must handle a breaking contract
 # change. An unset minimum version means that any client implementing the
 # advertised contract is accepted.
-SERVER_VERSION = os.environ.get("APP_VERSION", "4.8.0")
+SERVER_VERSION = os.environ.get("APP_VERSION", "4.9.0")
 MOBILE_CONTRACT_VERSION = 1
 MINIMUM_MOBILE_VERSION = os.environ.get("MINIMUM_MOBILE_VERSION") or None
 

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -14,7 +14,7 @@ info:
 
     Access tokens expire after 15 minutes. Refresh tokens expire after 7 days.
 
-  version: 4.8.0
+  version: 4.9.0
   license:
     name: O'Saasy License
     url: https://osaasy.dev/

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "dependencies": {
         "@mantine/charts": "^9.5.0",
         "@mantine/core": "^9.5.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "4.8.0",
+  "version": "4.9.0",
   "type": "module",
   "engines": {
     "node": ">=24.19.0 <25"

--- a/apps/web/src/config/releaseNotes.de.ts
+++ b/apps/web/src/config/releaseNotes.de.ts
@@ -2,6 +2,21 @@ import type { ReleaseNote } from './releaseNotes';
 
 export const germanReleaseNotes: ReleaseNote[] = [
   {
+    version: '4.9.0',
+    date: '2026-08-24',
+    title: 'Modernisierte Laufzeitumgebung',
+    sections: [
+      {
+        heading: 'Build- und Laufzeitunterstützung',
+        items: [
+          'Produktions- und Entwicklungs-Builds wurden auf Node 24 LTS und Python 3.14 vereinheitlicht',
+          'Explizite Node-Engine-Vorgaben verhindern Builds mit nicht unterstützten Laufzeitversionen',
+          'Die vollständige Anwendung und der Multi-Architektur-Container-Build wurden mit der modernen Laufzeitbasis validiert',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.8.0',
     date: '2026-08-24',
     title: 'Sichere Abhängigkeitsbasis',

--- a/apps/web/src/config/releaseNotes.ts
+++ b/apps/web/src/config/releaseNotes.ts
@@ -50,6 +50,21 @@ export interface ReleaseNote {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '4.9.0',
+    date: '2026-08-24',
+    title: 'Runtime Modernization',
+    sections: [
+      {
+        heading: 'Build and Runtime Support',
+        items: [
+          'Standardized production and development builds on Node 24 LTS and Python 3.14',
+          'Added explicit Node engine constraints to prevent unsupported build environments',
+          'Validated the complete application and multi-architecture container build on the modern runtime baseline',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.8.0',
     date: '2026-08-24',
     title: 'Dependency Security Baseline',


### PR DESCRIPTION
## Summary
- publish the Node 24 LTS and Python 3.14 runtime baseline as version 4.9.0
- synchronize server, API, web, and localized release metadata
- document supported runtime constraints

## Validation
- site runtime images built on Node 24 and Python 3.14
- dashboard: 18 frontend tests and 41 backend tests passed; lint and build passed
- docs: typecheck, build, and Docker build passed
- app validation runs in required CI before merge