### PR TITLE
chore: release ecosystem migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ A **secure multi-user** web application for tracking recurring expenses and inco
 
 ---
 
-## 🎉 What's New in v4.9.0
+## 🎉 What's New in v4.10.0
 
-**Runtime Modernization** - Production and development builds now use the supported Node 24 LTS and Python 3.14 runtime baseline.
+**Ecosystem Migrations** - The supported frontend and service libraries now use their current major release lines.
 
 ### Highlights
 
-- **Current Runtimes** - Node 24 LTS and Python 3.14 are the supported container and CI baseline
-- **Consistent Builds** - Engine constraints prevent accidental builds with unsupported Node releases
-- **Release Verification** - Backend, web, mobile, security, and multi-architecture container checks gate published images
+- **Modern Frontend** - Mantine 9, Vite 8, Vitest 4, and TypeScript 6 form the validated frontend baseline
+- **Current Services** - Stripe 15 and Gunicorn 26 are validated for the administration service
+- **Migration Coverage** - Automated tests, audits, production builds, and containers verify the major-version transitions
 
 ---
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -29,7 +29,7 @@ JWT_SECRET_KEY=
 # Version values exposed by the pre-auth mobile compatibility contract.
 # APP_VERSION normally matches the deployed release/image tag.
 # Leave MINIMUM_MOBILE_VERSION empty unless older mobile binaries must be blocked.
-# APP_VERSION=4.9.0
+# APP_VERSION=4.10.0
 # MINIMUM_MOBILE_VERSION=
 
 # =============================================================================

--- a/apps/server/config.py
+++ b/apps/server/config.py
@@ -315,7 +315,7 @@ DEFAULT_LOCALE = os.environ.get("DEFAULT_LOCALE", "en-US")
 # version: it only changes when a mobile client must handle a breaking contract
 # change. An unset minimum version means that any client implementing the
 # advertised contract is accepted.
-SERVER_VERSION = os.environ.get("APP_VERSION", "4.9.0")
+SERVER_VERSION = os.environ.get("APP_VERSION", "4.10.0")
 MOBILE_CONTRACT_VERSION = 1
 MINIMUM_MOBILE_VERSION = os.environ.get("MINIMUM_MOBILE_VERSION") or None
 

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -14,7 +14,7 @@ info:
 
     Access tokens expire after 15 minutes. Refresh tokens expire after 7 days.
 
-  version: 4.9.0
+  version: 4.10.0
   license:
     name: O'Saasy License
     url: https://osaasy.dev/

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,29 +1,29 @@
 {
   "name": "client",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "4.9.0",
+      "version": "4.10.0",
       "dependencies": {
-        "@mantine/charts": "^9.5.0",
-        "@mantine/core": "^9.5.0",
-        "@mantine/dates": "^9.5.0",
-        "@mantine/form": "^9.5.0",
-        "@mantine/hooks": "^9.5.0",
-        "@mantine/notifications": "^9.5.0",
+        "@mantine/charts": "^9.5.2",
+        "@mantine/core": "^9.5.2",
+        "@mantine/dates": "^9.5.2",
+        "@mantine/form": "^9.5.2",
+        "@mantine/hooks": "^9.5.2",
+        "@mantine/notifications": "^9.5.2",
         "@simplewebauthn/browser": "^13.3.0",
         "@tabler/icons-react": "^3.46.0",
         "axios": "^1.19.0",
-        "dayjs": "^1.11.21",
-        "i18next": "^26.3.5",
+        "dayjs": "^1.11.23",
+        "i18next": "^26.4.0",
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.8",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-i18next": "^17.0.10",
+        "react-i18next": "^17.0.12",
         "react-is": "^19.2.8",
         "react-router": "^8.3.0",
         "recharts": "^3.9.2"
@@ -34,13 +34,13 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.1",
+        "@testing-library/user-event": "^14.6.6",
         "@types/node": "^24.13.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.5",
-        "@vitest/coverage-v8": "^4.1.10",
-        "eslint": "^10.6.0",
+        "@vitejs/plugin-react": "^6.1.0",
+        "@vitest/coverage-v8": "^4.1.11",
+        "eslint": "^10.9.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "eslint-plugin-security": "^4.0.1",
@@ -49,8 +49,8 @@
         "sharp": "^0.35.3",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.64.0",
-        "vite": "^8.2.0",
-        "vitest": "^4.1.10"
+        "vite": "^8.2.2",
+        "vitest": "^4.1.11"
       },
       "engines": {
         "node": ">=24.19.0 <25"
@@ -1430,22 +1430,22 @@
       }
     },
     "node_modules/@mantine/charts": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@mantine/charts/-/charts-9.5.1.tgz",
-      "integrity": "sha512-JLa02nNyct+XVA3YSKGOVHoAMzO6Wg44uUB44SifDTejVFAiehHAM2GOcTqrYBAmYf/uodM/bdZktwNAug5irA==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@mantine/charts/-/charts-9.5.2.tgz",
+      "integrity": "sha512-9+3Gdk3dw4o1pwhYMsNPhVkDzflVHfcdGJIQtBTCweeqOkJcytt++HlvmD/O3NW/hBEDUutR68mreHU+gH5SwA==",
       "license": "MIT",
       "peerDependencies": {
-        "@mantine/core": "9.5.1",
-        "@mantine/hooks": "9.5.1",
+        "@mantine/core": "9.5.2",
+        "@mantine/hooks": "9.5.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "recharts": ">=3.2.1"
       }
     },
     "node_modules/@mantine/core": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-9.5.1.tgz",
-      "integrity": "sha512-3olDOYJBfW4kR37Aqdy/+FnYG7iNb5SPzOGeCp9dDxnt65K94sEqETDnXGJptOMO2xLm4KLJ/eBt3IIhJA7Z4Q==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-9.5.2.tgz",
+      "integrity": "sha512-yhnR+XVGmy7S66abvj/tF9SxzNJ+k60w+UZlC/vGOztrU2Cxpbr95gtrBrin4fpWyiE80qzVC2AY0WzaHPufWw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
@@ -1455,31 +1455,31 @@
         "type-fest": "^5.8.0"
       },
       "peerDependencies": {
-        "@mantine/hooks": "9.5.1",
+        "@mantine/hooks": "9.5.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/dates": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-9.5.1.tgz",
-      "integrity": "sha512-1FTIgF8L6AKEb+Ql53zVyCCp4JxvQp/AUDts5T/JEI7U0CZGpzg+FHGtmNShLR4ONuOfzOV1gkgU8INbxVJjag==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-9.5.2.tgz",
+      "integrity": "sha512-640r4aDYR7EfNV+qRqnIMC/HX0fuLiD8O4/qVVrLCgBV4w6ZtfcaTjLwDRR/F8uGIX5epNTujzhffz0n14HXCQ==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
-        "@mantine/core": "9.5.1",
-        "@mantine/hooks": "9.5.1",
+        "@mantine/core": "9.5.2",
+        "@mantine/hooks": "9.5.2",
         "dayjs": ">=1.0.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/form": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-9.5.1.tgz",
-      "integrity": "sha512-WsMZGBTsoG2Y/K+6QK0+GmsJxq5KzWHIzo65lRpkq/SwdenV9G+3m0LstlhI9i2/wQF83GfwP7mCbKMfzf00Eg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-9.5.2.tgz",
+      "integrity": "sha512-9zWyAvEIn5QGfDa7Mxf+iCeEnUHtIam2avY8Csx6PsHqWmRSl9eYfQFrofv6FcR6eAbVUzQHzL/gpqZ3BzPt9g==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -1491,34 +1491,34 @@
       }
     },
     "node_modules/@mantine/hooks": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.5.1.tgz",
-      "integrity": "sha512-2sK9OdWvrzKBOuWxLfQA5qcAJzxpzqNlKumaP7Uq0i7LDBQeY/sYgNiBWLwtW+iZw6fFXwPf0nI7q5VVpvqnNQ==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.5.2.tgz",
+      "integrity": "sha512-CsANdaF07VRhcvDCupIvAPtIqU1NxYSc+bhFCCasDHpgJOUQxmqeMOGCCGSjtOOEIs+E+pt2ZbbdfnygDYPybA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.0"
       }
     },
     "node_modules/@mantine/notifications": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-9.5.1.tgz",
-      "integrity": "sha512-/MIGWag8U20HTM4gOGSNVhmQ0n6YM2gdSR1NbtBffSh77nuzwPjr68UmpMc2WHFMi8OBlrSIcw9Xpe3YPfgnvQ==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-9.5.2.tgz",
+      "integrity": "sha512-2DQW2i6BlTGI7Vqp1a8IN03Q2CI/nMd7joJu7RGMTDhnnD0rhAhQtu/NwGdmq5gl4vFCpzzwHtH359Do2MlRGg==",
       "license": "MIT",
       "dependencies": {
-        "@mantine/store": "9.5.1",
+        "@mantine/store": "9.5.2",
         "react-transition-group": "4.4.5"
       },
       "peerDependencies": {
-        "@mantine/core": "9.5.1",
-        "@mantine/hooks": "9.5.1",
+        "@mantine/core": "9.5.2",
+        "@mantine/hooks": "9.5.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/store": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-9.5.1.tgz",
-      "integrity": "sha512-nDmA9S+qnQQ61KYgph06Wt2cx1tj3Z6eeyK3HvFeuLb5FcGycbITsVy/+3LltH2qdqkpNeAA9wQ926NFjn5hvA==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-9.5.2.tgz",
+      "integrity": "sha512-vpOS9QwqaJ1KOPr8MdQXYXFDIPkDg1KCr5O8FOGVZIGfsei1vvQsvvmMGGEKGmEE/4FCYwEfhCUWaAVw2psVzw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.0"
@@ -1968,9 +1968,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.6.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.4.tgz",
-      "integrity": "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==",
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2390,9 +2390,9 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
-      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.0.tgz",
+      "integrity": "sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2404,6 +2404,7 @@
       "peerDependencies": {
         "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
         "babel-plugin-react-compiler": "^1.0.0",
+        "oxc-transform-react": "^0.145.0",
         "vite": "^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -2412,18 +2413,21 @@
         },
         "babel-plugin-react-compiler": {
           "optional": true
+        },
+        "oxc-transform-react": {
+          "optional": true
         }
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
-      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -2437,8 +2441,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.10",
-        "vitest": "4.1.10"
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -2447,16 +2451,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2465,13 +2469,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2492,9 +2496,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2505,13 +2509,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2519,14 +2523,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2535,9 +2539,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2545,13 +2549,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -3097,9 +3101,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.22",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.22.tgz",
-      "integrity": "sha512-1YRnxzt/AabP3GHxnaB9/b+ZScCKu5TeF+co+BWG+lnWVIwEcTFc1FVE0WLNmNO3sA6GGXL40i5qkHfbLzpwrg==",
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3323,9 +3327,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.0.tgz",
+      "integrity": "sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -3932,9 +3936,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.3.6",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
-      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.4.0.tgz",
+      "integrity": "sha512-rsmK5bFqsD1AetSFSIa43wtNR4WpvvH4p0tLEsTxkC7QTrfdFm06nbQ95bh8Og4wwaCnUEcm9DVYL2cgxitiQg==",
       "funding": [
         {
           "type": "individual",
@@ -5047,12 +5051,12 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
-      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.12.tgz",
+      "integrity": "sha512-lFWPEGkxQ6RhusdUkysFBD58VHfSSzvHBzqMgN0SvfVpdQGfwtNkStTqdy08/sJd7s807qqutgx93fRpD0DJ3Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
+        "@babel/runtime": "^7.29.7",
         "html-parse-stringify": "^4.0.1",
         "use-sync-external-store": "^1.6.0"
       },
@@ -5914,16 +5918,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.25",
-        "rolldown": "~1.2.1",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -5940,7 +5944,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.4.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -6007,19 +6011,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -6047,12 +6051,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "4.9.0",
+  "version": "4.10.0",
   "type": "module",
   "engines": {
     "node": ">=24.19.0 <25"
@@ -25,22 +25,22 @@
     "generate-icons": "node scripts/generate-icons.mjs"
   },
   "dependencies": {
-    "@mantine/charts": "^9.5.0",
-    "@mantine/core": "^9.5.0",
-    "@mantine/dates": "^9.5.0",
-    "@mantine/form": "^9.5.0",
-    "@mantine/hooks": "^9.5.0",
-    "@mantine/notifications": "^9.5.0",
+    "@mantine/charts": "^9.5.2",
+    "@mantine/core": "^9.5.2",
+    "@mantine/dates": "^9.5.2",
+    "@mantine/form": "^9.5.2",
+    "@mantine/hooks": "^9.5.2",
+    "@mantine/notifications": "^9.5.2",
     "@simplewebauthn/browser": "^13.3.0",
     "@tabler/icons-react": "^3.46.0",
     "axios": "^1.19.0",
-    "dayjs": "^1.11.21",
-    "i18next": "^26.3.5",
+    "dayjs": "^1.11.23",
+    "i18next": "^26.4.0",
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.8",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-i18next": "^17.0.10",
+    "react-i18next": "^17.0.12",
     "react-is": "^19.2.8",
     "react-router": "^8.3.0",
     "recharts": "^3.9.2"
@@ -51,13 +51,13 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
-    "@testing-library/user-event": "^14.6.1",
+    "@testing-library/user-event": "^14.6.6",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.5",
-    "@vitest/coverage-v8": "^4.1.10",
-    "eslint": "^10.6.0",
+    "@vitejs/plugin-react": "^6.1.0",
+    "@vitest/coverage-v8": "^4.1.11",
+    "eslint": "^10.9.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "eslint-plugin-security": "^4.0.1",
@@ -66,7 +66,7 @@
     "sharp": "^0.35.3",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.64.0",
-    "vite": "^8.2.0",
-    "vitest": "^4.1.10"
+    "vite": "^8.2.2",
+    "vitest": "^4.1.11"
   }
 }

--- a/apps/web/src/config/releaseNotes.de.ts
+++ b/apps/web/src/config/releaseNotes.de.ts
@@ -2,6 +2,21 @@ import type { ReleaseNote } from './releaseNotes';
 
 export const germanReleaseNotes: ReleaseNote[] = [
   {
+    version: '4.10.0',
+    date: '2026-08-24',
+    title: 'Ökosystem-Migrationen',
+    sections: [
+      {
+        heading: 'Große Bibliotheksaktualisierungen',
+        items: [
+          'Mantine 9, Vite 8, Vitest 4 und TypeScript 6 wurden für die unterstützten Frontend-Oberflächen validiert',
+          'Stripe 15 und Gunicorn 26 wurden für den Verwaltungsdienst validiert',
+          'Kompatibilitätstests sowie Audit-, Produktions-Build- und Containerprüfungen wurden für die Migrationen aktualisiert',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.9.0',
     date: '2026-08-24',
     title: 'Modernisierte Laufzeitumgebung',

--- a/apps/web/src/config/releaseNotes.ts
+++ b/apps/web/src/config/releaseNotes.ts
@@ -50,6 +50,21 @@ export interface ReleaseNote {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '4.10.0',
+    date: '2026-08-24',
+    title: 'Ecosystem Migrations',
+    sections: [
+      {
+        heading: 'Major Library Upgrades',
+        items: [
+          'Validated Mantine 9, Vite 8, Vitest 4, and TypeScript 6 across the supported frontend surfaces',
+          'Validated Stripe 15 and Gunicorn 26 for the administration service',
+          'Updated compatibility tests and completed audit, production build, and container verification for the migrations',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.9.0',
     date: '2026-08-24',
     title: 'Runtime Modernization',


### PR DESCRIPTION
## Summary
- update the core web dependency line to current Mantine 9, Vite 8, Vitest 4, and related patch releases
- publish ecosystem migration metadata as version 4.10.0
- synchronize server, API, web, and localized release metadata

## Validation
- web: 67 tests passed; lint completed with four existing warnings; build and npm audit passed
- production Docker image billmanager:4.10.0 built successfully
- companion dashboard: 18 frontend and 41 backend tests passed; lint, audit, build, and Docker build passed
- companion docs: TypeScript 6 typecheck, build, and Docker build passed