### PR TITLE
chore: release deterministic dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /apps/web
+    schedule:
+      interval: weekly
+    groups:
+      web-dependencies:
+        patterns: ["*"]
+  - package-ecosystem: npm
+    directory: /apps/mobile
+    schedule:
+      interval: weekly
+    groups:
+      mobile-dependencies:
+        patterns: ["*"]
+  - package-ecosystem: pip
+    directory: /apps/server
+    schedule:
+      interval: weekly
+    groups:
+      server-dependencies:
+        patterns: ["*"]
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,12 +42,20 @@ jobs:
         with:
           python-version: '3.14'
           cache: 'pip'
-          cache-dependency-path: apps/server/requirements.txt
+          cache-dependency-path: apps/server/requirements.lock
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Verify Python dependency lock
+        run: |
+          uv pip compile apps/server/requirements.txt --python-version 3.14 --no-header --output-file /tmp/requirements.lock
+          diff -u apps/server/requirements.lock /tmp/requirements.lock
 
       - name: Install Python dependencies
         run: |
           cd apps/server
-          pip install -r requirements.txt
+          pip install -r requirements.lock
 
       - name: Run pytest (self-hosted)
         env:
@@ -70,7 +78,7 @@ jobs:
 
       - name: Run pip-audit
         run: |
-          pip-audit -r apps/server/requirements.txt
+          pip-audit -r apps/server/requirements.lock
 
   test-frontend:
     name: Frontend Tests & Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy Python requirements and install
-COPY apps/server/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY apps/server/requirements.lock .
+RUN pip install --no-cache-dir -r requirements.lock
 
 # Copy only the backend application. Local repository files and credentials
 # must never become part of the runtime image.

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ bandit:
 	cd apps/server && ../../$(VENV)/bin/bandit -r . -x tests -c bandit.yaml -f txt
 
 pip-audit:
-	timeout $(PIP_AUDIT_TIMEOUT) bash -lc 'source $(VENV)/bin/activate && pip-audit -r apps/server/requirements.txt'
+	timeout $(PIP_AUDIT_TIMEOUT) bash -lc 'source $(VENV)/bin/activate && pip-audit -r apps/server/requirements.lock'
 
 test-db-up:
 	@./scripts/test-backend.sh --db-only

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ A **secure multi-user** web application for tracking recurring expenses and inco
 
 ---
 
-## 🎉 What's New in v4.10.0
+## 🎉 What's New in v4.11.0
 
-**Ecosystem Migrations** - The supported frontend and service libraries now use their current major release lines.
+**Deterministic Dependencies** - Application builds now use an exact, reviewable Python dependency lock.
 
 ### Highlights
 
-- **Modern Frontend** - Mantine 9, Vite 8, Vitest 4, and TypeScript 6 form the validated frontend baseline
-- **Current Services** - Stripe 15 and Gunicorn 26 are validated for the administration service
-- **Migration Coverage** - Automated tests, audits, production builds, and containers verify the major-version transitions
+- **Reproducible Backend Builds** - The server, CI, audits, and container image install the same exact Python dependency graph
+- **Lockfile Enforcement** - CI verifies that the committed lockfile matches the declared requirements
+- **Automated Maintenance** - Grouped Dependabot updates cover npm, Python, Docker, and GitHub Actions dependencies
 
 ---
 

--- a/TEST-SUITE.md
+++ b/TEST-SUITE.md
@@ -138,7 +138,7 @@ cat /tmp/billmanager-test-results/flask.log
 ```
 
 Common issues:
-- Missing dependencies: `pip install -r apps/server/requirements.txt`
+- Missing dependencies: `pip install -r apps/server/requirements.lock`
 - Database connection: Verify `DATABASE_URL`
 - Port conflict: Kill process on 5001
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -29,7 +29,7 @@ JWT_SECRET_KEY=
 # Version values exposed by the pre-auth mobile compatibility contract.
 # APP_VERSION normally matches the deployed release/image tag.
 # Leave MINIMUM_MOBILE_VERSION empty unless older mobile binaries must be blocked.
-# APP_VERSION=4.10.0
+# APP_VERSION=4.11.0
 # MINIMUM_MOBILE_VERSION=
 
 # =============================================================================

--- a/apps/server/config.py
+++ b/apps/server/config.py
@@ -315,7 +315,7 @@ DEFAULT_LOCALE = os.environ.get("DEFAULT_LOCALE", "en-US")
 # version: it only changes when a mobile client must handle a breaking contract
 # change. An unset minimum version means that any client implementing the
 # advertised contract is accepted.
-SERVER_VERSION = os.environ.get("APP_VERSION", "4.10.0")
+SERVER_VERSION = os.environ.get("APP_VERSION", "4.11.0")
 MOBILE_CONTRACT_VERSION = 1
 MINIMUM_MOBILE_VERSION = os.environ.get("MINIMUM_MOBILE_VERSION") or None
 

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -14,7 +14,7 @@ info:
 
     Access tokens expire after 15 minutes. Refresh tokens expire after 7 days.
 
-  version: 4.10.0
+  version: 4.11.0
   license:
     name: O'Saasy License
     url: https://osaasy.dev/

--- a/apps/server/requirements.lock
+++ b/apps/server/requirements.lock
@@ -1,0 +1,203 @@
+alembic==1.19.1
+    # via flask-migrate
+apscheduler==3.11.3
+    # via -r apps/server/requirements.txt
+authlib==1.7.2
+    # via -r apps/server/requirements.txt
+bandit==1.9.4
+    # via -r apps/server/requirements.txt
+blinker==1.9.0
+    # via flask
+boolean-py==5.0
+    # via license-expression
+cachecontrol==0.14.4
+    # via pip-audit
+cbor2==6.1.4
+    # via webauthn
+certifi==2026.7.22
+    # via requests
+cffi==2.1.1
+    # via cryptography
+charset-normalizer==3.5.1
+    # via requests
+click==8.4.2
+    # via flask
+coverage==7.15.4
+    # via pytest-cov
+cryptography==50.0.0
+    # via
+    #   authlib
+    #   joserfc
+    #   pyopenssl
+    #   webauthn
+cyclonedx-python-lib==11.12.0
+    # via pip-audit
+defusedxml==0.7.1
+    # via py-serializable
+deprecated==1.3.1
+    # via limits
+filelock==3.32.4
+    # via cachecontrol
+flask==3.1.3
+    # via
+    #   -r apps/server/requirements.txt
+    #   flask-cors
+    #   flask-limiter
+    #   flask-migrate
+    #   flask-sqlalchemy
+flask-cors==6.0.5
+    # via -r apps/server/requirements.txt
+flask-limiter==4.1.1
+    # via -r apps/server/requirements.txt
+flask-migrate==4.1.0
+    # via -r apps/server/requirements.txt
+flask-sqlalchemy==3.1.1
+    # via
+    #   -r apps/server/requirements.txt
+    #   flask-migrate
+flask-talisman==1.1.0
+    # via -r apps/server/requirements.txt
+greenlet==3.5.5
+    # via sqlalchemy
+gunicorn==26.0.0
+    # via -r apps/server/requirements.txt
+idna==3.19
+    # via requests
+iniconfig==2.3.0
+    # via pytest
+itsdangerous==2.2.0
+    # via flask
+jinja2==3.1.6
+    # via flask
+joserfc==1.7.4
+    # via authlib
+license-expression==30.4.4
+    # via cyclonedx-python-lib
+limits==5.8.0
+    # via flask-limiter
+mako==1.4.1
+    # via alembic
+markdown-it-py==4.2.0
+    # via rich
+markupsafe==3.0.3
+    # via
+    #   flask
+    #   jinja2
+    #   mako
+    #   werkzeug
+mdurl==0.1.2
+    # via markdown-it-py
+msgpack==1.2.1
+    # via cachecontrol
+ordered-set==4.1.0
+    # via flask-limiter
+packageurl-python==0.17.6
+    # via cyclonedx-python-lib
+packaging==26.3
+    # via
+    #   gunicorn
+    #   limits
+    #   pip-audit
+    #   pip-requirements-parser
+    #   pytest
+pip==26.2.1
+    # via pip-api
+pip-api==0.0.34
+    # via pip-audit
+pip-audit==2.10.1
+    # via -r apps/server/requirements.txt
+pip-requirements-parser==32.0.1
+    # via pip-audit
+platformdirs==4.11.3
+    # via pip-audit
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
+psycopg==3.3.4
+    # via -r apps/server/requirements.txt
+psycopg-binary==3.3.4
+    # via psycopg
+py-serializable==2.1.0
+    # via cyclonedx-python-lib
+pyasn1==0.6.4
+    # via
+    #   pyasn1-modules
+    #   webauthn
+pyasn1-modules==0.4.2
+    # via webauthn
+pycparser==3.0
+    # via cffi
+pygments==2.21.0
+    # via
+    #   pytest
+    #   rich
+pyjwt==2.13.0
+    # via -r apps/server/requirements.txt
+pyopenssl==26.4.0
+    # via webauthn
+pyparsing==3.3.2
+    # via pip-requirements-parser
+pytest==9.1.1
+    # via
+    #   -r apps/server/requirements.txt
+    #   pytest-cov
+pytest-cov==7.1.0
+    # via -r apps/server/requirements.txt
+pyyaml==6.0.3
+    # via
+    #   -r apps/server/requirements.txt
+    #   bandit
+    #   responses
+requests==2.34.2
+    # via
+    #   -r apps/server/requirements.txt
+    #   cachecontrol
+    #   pip-audit
+    #   resend
+    #   responses
+    #   stripe
+resend==2.36.0
+    # via -r apps/server/requirements.txt
+responses==0.26.2
+    # via -r apps/server/requirements.txt
+rich==15.0.0
+    # via
+    #   bandit
+    #   pip-audit
+sortedcontainers==2.4.0
+    # via cyclonedx-python-lib
+sqlalchemy==2.0.52
+    # via
+    #   alembic
+    #   flask-sqlalchemy
+stevedore==5.9.1
+    # via bandit
+stripe==15.5.0
+    # via -r apps/server/requirements.txt
+tomli==2.4.1
+    # via pip-audit
+tomli-w==1.2.0
+    # via pip-audit
+typing-extensions==4.16.0
+    # via
+    #   alembic
+    #   flask-limiter
+    #   limits
+    #   resend
+    #   sqlalchemy
+    #   stripe
+tzlocal==5.4.4
+    # via apscheduler
+urllib3==2.7.0
+    # via
+    #   requests
+    #   responses
+webauthn==3.0.0
+    # via -r apps/server/requirements.txt
+werkzeug==3.1.8
+    # via
+    #   flask
+    #   flask-cors
+wrapt==2.3.0
+    # via deprecated

--- a/apps/server/requirements.txt
+++ b/apps/server/requirements.txt
@@ -1,3 +1,5 @@
+# Regenerate requirements.lock after edits:
+# uv pip compile apps/server/requirements.txt --python-version 3.14 --no-header --output-file apps/server/requirements.lock
 flask==3.1.3
 flask-cors==6.0.5
 flask-limiter==4.1.1

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "4.10.0",
+      "version": "4.11.0",
       "dependencies": {
         "@mantine/charts": "^9.5.2",
         "@mantine/core": "^9.5.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "4.10.0",
+  "version": "4.11.0",
   "type": "module",
   "engines": {
     "node": ">=24.19.0 <25"

--- a/apps/web/src/__tests__/setup.ts
+++ b/apps/web/src/__tests__/setup.ts
@@ -4,7 +4,6 @@
  */
 import '@testing-library/jest-dom'
 import { vi } from 'vitest'
-import '../i18n'
 
 // Mock window.matchMedia for components that use media queries
 Object.defineProperty(window, 'matchMedia', {
@@ -53,6 +52,10 @@ const localStorageMock = {
   clear: vi.fn(),
 }
 Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+// Initialize i18n only after the storage API has been installed. Newer Node
+// releases expose an incomplete localStorage shim unless a backing file is set.
+await import('../i18n')
 
 // Mock scrollTo
 window.scrollTo = vi.fn()

--- a/apps/web/src/config/releaseNotes.de.ts
+++ b/apps/web/src/config/releaseNotes.de.ts
@@ -2,6 +2,21 @@ import type { ReleaseNote } from './releaseNotes';
 
 export const germanReleaseNotes: ReleaseNote[] = [
   {
+    version: '4.11.0',
+    date: '2026-08-24',
+    title: 'Deterministische Abhängigkeiten',
+    sections: [
+      {
+        heading: 'Zuverlässige Builds',
+        items: [
+          'Eine exakte Python-Abhängigkeitssperre wird jetzt für lokale Einrichtung, CI-Sicherheitsaudits und Produktions-Container-Builds verwendet',
+          'Eine CI-Konsistenzprüfung verhindert Abweichungen zwischen den deklarierten Anforderungen und der eingecheckten Sperrdatei',
+          'Gruppierte Dependabot-Aktualisierungen pflegen npm-, Python-, Docker- und GitHub-Actions-Abhängigkeiten',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.10.0',
     date: '2026-08-24',
     title: 'Ökosystem-Migrationen',

--- a/apps/web/src/config/releaseNotes.ts
+++ b/apps/web/src/config/releaseNotes.ts
@@ -50,6 +50,21 @@ export interface ReleaseNote {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '4.11.0',
+    date: '2026-08-24',
+    title: 'Deterministic Dependencies',
+    sections: [
+      {
+        heading: 'Build Reliability',
+        items: [
+          'Added an exact Python dependency lock shared by local setup, CI security audits, and production container builds',
+          'Added a CI consistency check that prevents declared requirements and the committed lockfile from drifting',
+          'Enabled grouped Dependabot maintenance for npm, Python, Docker, and GitHub Actions dependencies',
+        ],
+      },
+    ],
+  },
+  {
     version: '4.10.0',
     date: '2026-08-24',
     title: 'Ecosystem Migrations',

--- a/scripts/bootstrap-dev.sh
+++ b/scripts/bootstrap-dev.sh
@@ -43,7 +43,7 @@ setup_backend() {
   # Install backend Python dependencies into the repo-local virtualenv.
   source "${VENV_DIR}/bin/activate"
   python -m pip install --upgrade pip
-  pip install -r "${ROOT_DIR}/apps/server/requirements.txt"
+  pip install -r "${ROOT_DIR}/apps/server/requirements.lock"
 }
 
 setup_node_workspace() {


### PR DESCRIPTION
## Summary
- add and enforce an exact Python dependency lock across development, CI, audits, and container builds
- add grouped Dependabot maintenance for npm, Python, Docker, and GitHub Actions
- make frontend test bootstrap robust to the current Node 24 localStorage behavior
- publish v4.11.0 application metadata and localized release notes

## Validation
- exact lock regeneration and diff
- pip-audit: no known vulnerabilities
- targeted release-note tests
- production frontend build
- production Docker image build
- full CI required before merge