### PR TITLE
chore(deps): refresh server dependency lock

### DIFF
--- a/apps/server/requirements.lock
+++ b/apps/server/requirements.lock
@@ -2,7 +2,7 @@ alembic==1.19.1
     # via flask-migrate
 apscheduler==3.11.3
     # via -r apps/server/requirements.txt
-authlib==1.7.2
+authlib==1.8.0
     # via -r apps/server/requirements.txt
 bandit==1.9.4
     # via -r apps/server/requirements.txt
@@ -22,7 +22,7 @@ charset-normalizer==3.5.1
     # via requests
 click==8.5.0
     # via flask
-coverage==7.15.4
+coverage==7.16.0
     # via pytest-cov
 cryptography==50.0.1
     # via
@@ -36,7 +36,7 @@ defusedxml==0.7.1
     # via py-serializable
 deprecated==1.3.1
     # via limits
-filelock==3.32.4
+filelock==3.32.5
     # via cachecontrol
 flask==3.1.3
     # via
@@ -59,7 +59,7 @@ flask-talisman==1.1.0
     # via -r apps/server/requirements.txt
 greenlet==3.5.5
     # via sqlalchemy
-gunicorn==26.1.0
+gunicorn==26.2.0
     # via -r apps/server/requirements.txt
 idna==3.19
     # via requests
@@ -69,7 +69,7 @@ itsdangerous==2.2.0
     # via flask
 jinja2==3.1.6
     # via flask
-joserfc==1.7.4
+joserfc==1.7.5
     # via authlib
 license-expression==30.4.4
     # via cyclonedx-python-lib
@@ -107,15 +107,15 @@ pip-audit==2.10.1
     # via -r apps/server/requirements.txt
 pip-requirements-parser==32.0.1
     # via pip-audit
-platformdirs==4.11.5
+platformdirs==4.11.7
     # via pip-audit
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-psycopg==3.3.4
+psycopg==3.3.5
     # via -r apps/server/requirements.txt
-psycopg-binary==3.3.4
+psycopg-binary==3.3.5
     # via psycopg
 py-serializable==2.1.0
     # via cyclonedx-python-lib
@@ -156,7 +156,7 @@ requests==2.34.2
     #   resend
     #   responses
     #   stripe
-resend==2.39.0
+resend==2.42.0
     # via -r apps/server/requirements.txt
 responses==0.26.3
     # via -r apps/server/requirements.txt
@@ -172,7 +172,7 @@ sqlalchemy==2.0.52
     #   flask-sqlalchemy
 stevedore==5.9.1
     # via bandit
-stripe==15.5.1
+stripe==15.6.0
     # via -r apps/server/requirements.txt
 tomli==2.4.1
     # via pip-audit
@@ -198,5 +198,5 @@ werkzeug==3.1.8
     # via
     #   flask
     #   flask-cors
-wrapt==2.3.0
+wrapt==2.4.0
     # via deprecated

--- a/apps/server/requirements.txt
+++ b/apps/server/requirements.txt
@@ -4,13 +4,13 @@ flask==3.1.3
 flask-cors==6.0.5
 flask-limiter==4.1.1
 flask-talisman==1.1.0
-gunicorn==26.1.0
+gunicorn==26.2.0
 flask-sqlalchemy==3.1.1
 psycopg[binary]>=3.3.4
 flask-migrate==4.1.0
 PyJWT==2.13.0
-resend==2.39.0
-stripe==15.5.1
+resend==2.42.0
+stripe==15.6.0
 APScheduler==3.11.3
 requests>=2.34.2
 authlib>=1.7.2
@@ -20,7 +20,7 @@ PyYAML>=6.0.3
 # Testing
 pytest>=9.1.1
 pytest-cov>=7.1.0
-responses>=0.26.2
+responses>=0.26.3
 
 # Security scanning
 bandit>=1.9.4


### PR DESCRIPTION
Replaces Dependabot PR #111 with the regenerated Python lockfile so the updated server dependencies are installed by CI and the production image.