### PR TITLE
fix(billing): fail closed and process Stripe webhooks reliably

### DIFF
--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -27,7 +27,7 @@ from flask_migrate import Migrate
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_talisman import Talisman
-from sqlalchemy import func, extract, desc, or_
+from sqlalchemy import func, extract, desc, or_, text
 from sqlalchemy.exc import IntegrityError
 
 from models import (
@@ -38,6 +38,7 @@ from models import (
     Payment,
     RefreshToken,
     Subscription,
+    StripeWebhookEvent,
     UserInvite,
     UserDevice,
     BillShare,
@@ -69,6 +70,8 @@ from services.stripe_service import (
     cancel_subscription,
     update_subscription,
     STRIPE_PUBLISHABLE_KEY,
+    get_billing_readiness,
+    log_missing_billing_configuration,
 )
 from services.telemetry import telemetry
 from services.scheduler import scheduler
@@ -1589,8 +1592,10 @@ def register():
         # Generate email verification token
         token = user.generate_email_verification_token()
 
+    # Trial provisioning must survive temporary payment configuration outages.
+    billing_enabled = ENABLE_BILLING
     # Set trial only in SaaS mode with billing
-    if ENABLE_BILLING:
+    if billing_enabled:
         user.trial_ends_at = datetime.datetime.now(datetime.timezone.utc) + timedelta(
             days=14
         )
@@ -1614,7 +1619,7 @@ def register():
     user.accessible_databases.append(default_db)
 
     # Create subscription only in SaaS mode with billing
-    if ENABLE_BILLING:
+    if billing_enabled:
         subscription = Subscription(
             user_id=user.id, status="trialing", trial_ends_at=user.trial_ends_at
         )
@@ -1870,6 +1875,10 @@ def billing_usage():
 @jwt_required
 def create_checkout():
     """Create a Stripe Checkout session for subscription."""
+    readiness = get_billing_readiness()
+    if not readiness["billing_enabled"]:
+        log_missing_billing_configuration()
+        return jsonify({"success": False, "error": "Billing is not ready"}), 503
     user = db.session.get(User, g.jwt_user_id)
     if not user:
         return jsonify({"success": False, "error": "User not found"}), 404
@@ -2088,173 +2097,173 @@ def billing_status():
 
 @api_v2_bp.route("/webhooks/stripe", methods=["POST"])
 def stripe_webhook():
-    """Handle Stripe webhook events."""
+    """Handle verified Stripe events transactionally and in order."""
     payload = request.get_data()
     sig_header = request.headers.get("Stripe-Signature")
-
     if not sig_header:
         return jsonify({"error": "Missing signature"}), 400
 
     event = construct_webhook_event(payload, sig_header)
-
     if isinstance(event, dict) and "error" in event:
+        if event.get("error_code") == "configuration" or event.get("error") == "Webhook secret not configured":
+            log_missing_billing_configuration()
+            return jsonify({"error": "Webhook secret not configured"}), 503
         return jsonify({"error": event["error"]}), 400
+
+    supported = {
+        "checkout.session.completed", "invoice.paid", "invoice.payment_failed",
+        "customer.subscription.deleted", "customer.subscription.updated",
+    }
+    event_id = event.get("id")
+    event_created = event.get("created")
+    if event.get("type") in supported and (
+        not isinstance(event_id, str) or not event_id.strip()
+        or isinstance(event_created, bool) or not isinstance(event_created, int)
+        or event_created < 0
+    ):
+        return jsonify({"error": "Invalid webhook event"}), 400
 
     event_type = event.get("type")
     data = event.get("data", {}).get("object", {})
-
-    logger.info(f"Stripe webhook received: {event_type}")
+    subscription_id = data.get("subscription") if event_type in {
+        "checkout.session.completed", "invoice.paid", "invoice.payment_failed"
+    } else data.get("id")
+    if event_type in supported and (
+        (subscription_id is not None and (not isinstance(subscription_id, str) or not subscription_id.strip()))
+        or (event_type not in {"invoice.paid", "invoice.payment_failed"} and not subscription_id)
+    ):
+        return jsonify({"error": "Invalid webhook subscription identity"}), 400
 
     try:
         if event_type == "checkout.session.completed":
-            # Payment successful, activate subscription
+            user_id = data.get("metadata", {}).get("user_id")
+            if user_id:
+                # Different checkout sessions may concern the same local user.
+                db.session.execute(
+                    text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
+                    {"lock_key": f"stripe-user:{int(user_id)}"},
+                )
+        if subscription_id:
+            db.session.execute(
+                text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
+                {"lock_key": f"stripe-subscription:{subscription_id}"},
+            )
+
+        db.session.add(StripeWebhookEvent(event_id=event_id, event_created=event_created))
+        db.session.flush()
+        if event_type not in supported:
+            db.session.commit()
+            return jsonify({"received": True}), 200
+
+        # Stripe also emits invoice events for one-off, non-subscription invoices.
+        if event_type in {"invoice.paid", "invoice.payment_failed"} and not subscription_id:
+            db.session.commit()
+            return jsonify({"received": True}), 200
+
+        subscription = None
+        if subscription_id:
+            subscription = Subscription.query.filter_by(
+                stripe_subscription_id=subscription_id
+            ).first()
+        if event_type != "checkout.session.completed" and subscription_id and not subscription:
+            raise RuntimeError("Stripe subscription is not present locally yet")
+        if subscription and subscription.stripe_last_event_created is not None:
+            if event_created < subscription.stripe_last_event_created:
+                db.session.commit()
+                return jsonify({"received": True, "stale": True}), 200
+            if event_created == subscription.stripe_last_event_created:
+                # Stripe timestamps have second precision, not a total event order.
+                # Reconcile ties from the provider rather than retrying forever or
+                # choosing arbitrarily between two valid events in the same second.
+                details = get_subscription(subscription_id)
+                if "error" in details or not details.get("status"):
+                    raise RuntimeError("Unable to reconcile simultaneous Stripe events")
+                trusted_plan = get_plan_for_stripe_price_id(details.get("price_id"))
+                if not trusted_plan:
+                    raise RuntimeError("Unable to reconcile Stripe subscription price")
+                subscription.status = details["status"]
+                subscription.tier, subscription.billing_interval = trusted_plan
+                subscription.plan = "_".join(trusted_plan)
+                subscription.current_period_start = datetime.datetime.fromtimestamp(details["current_period_start"])
+                subscription.current_period_end = datetime.datetime.fromtimestamp(details["current_period_end"])
+                canceled_at = details.get("canceled_at")
+                subscription.canceled_at = datetime.datetime.fromtimestamp(canceled_at) if canceled_at else (
+                    datetime.datetime.now(datetime.timezone.utc) if details.get("cancel_at_period_end") else None
+                )
+                db.session.commit()
+                return jsonify({"received": True}), 200
+
+        if event_type == "checkout.session.completed":
             metadata = data.get("metadata", {})
             user_id = metadata.get("user_id")
-            customer_id = data.get("customer")
-            subscription_id = data.get("subscription")
-
             if user_id:
                 user = db.session.get(User, int(user_id))
                 if user:
-                    sub_details = get_subscription(subscription_id)
-                    trusted_plan = get_plan_for_stripe_price_id(
-                        sub_details.get("price_id") if "error" not in sub_details else None
-                    )
+                    if user.subscription and user.subscription.stripe_subscription_id not in (None, subscription_id):
+                        # Do not orphan an existing paid subscription. Replacement
+                        # needs an explicit operator reconciliation policy.
+                        raise RuntimeError("Conflicting Stripe subscription association")
+                    details = get_subscription(subscription_id)
+                    trusted_plan = get_plan_for_stripe_price_id(details.get("price_id"))
                     if not trusted_plan:
-                        raise ValueError("Stripe subscription uses an unknown price ID")
+                        raise RuntimeError("Unable to reconcile Stripe subscription")
                     tier, interval = trusted_plan
-
-                    if not user.subscription:
-                        subscription = Subscription(user_id=user.id)
+                    subscription = user.subscription or Subscription(user_id=user.id)
+                    if subscription not in db.session:
                         db.session.add(subscription)
-                    else:
-                        subscription = user.subscription
-
-                    subscription.stripe_customer_id = customer_id
+                    subscription.stripe_customer_id = data.get("customer")
                     subscription.stripe_subscription_id = subscription_id
                     subscription.status = "active"
                     subscription.tier = tier
                     subscription.billing_interval = interval
-                    subscription.plan = f"{tier}_{interval}"  # e.g., "basic_monthly"
-
-                    if "error" not in sub_details:
-                        subscription.current_period_start = (
-                            datetime.datetime.fromtimestamp(
-                                sub_details["current_period_start"]
-                            )
-                        )
-                        subscription.current_period_end = (
-                            datetime.datetime.fromtimestamp(
-                                sub_details["current_period_end"]
-                            )
-                        )
-
-                    db.session.commit()
-                    logger.info(
-                        f"Subscription activated for user {user_id}: {tier}/{interval}"
-                    )
-
+                    subscription.plan = f"{tier}_{interval}"
+                    if "error" not in details:
+                        subscription.current_period_start = datetime.datetime.fromtimestamp(details["current_period_start"])
+                        subscription.current_period_end = datetime.datetime.fromtimestamp(details["current_period_end"])
         elif event_type == "invoice.paid":
-            # Recurring payment successful
-            subscription_id = data.get("subscription")
-            if subscription_id:
-                subscription = Subscription.query.filter_by(
-                    stripe_subscription_id=subscription_id
-                ).first()
-                if subscription:
-                    subscription.status = "active"
-                    sub_details = get_subscription(subscription_id)
-                    if "error" not in sub_details:
-                        subscription.current_period_start = (
-                            datetime.datetime.fromtimestamp(
-                                sub_details["current_period_start"]
-                            )
-                        )
-                        subscription.current_period_end = (
-                            datetime.datetime.fromtimestamp(
-                                sub_details["current_period_end"]
-                            )
-                        )
-                    db.session.commit()
-                    logger.info(
-                        f"Subscription renewed for subscription {subscription_id}"
-                    )
-
+            subscription.status = "active"
+            details = get_subscription(subscription_id)
+            if "error" in details:
+                raise RuntimeError("Unable to reconcile Stripe subscription")
+            subscription.current_period_start = datetime.datetime.fromtimestamp(details["current_period_start"])
+            subscription.current_period_end = datetime.datetime.fromtimestamp(details["current_period_end"])
         elif event_type == "invoice.payment_failed":
-            # Payment failed
-            subscription_id = data.get("subscription")
-            if subscription_id:
-                subscription = Subscription.query.filter_by(
-                    stripe_subscription_id=subscription_id
-                ).first()
-                if subscription:
-                    subscription.status = "past_due"
-                    db.session.commit()
-                    logger.warning(f"Payment failed for subscription {subscription_id}")
-
+            subscription.status = "past_due"
         elif event_type == "customer.subscription.deleted":
-            # Subscription canceled
-            subscription_id = data.get("id")
-            if subscription_id:
-                subscription = Subscription.query.filter_by(
-                    stripe_subscription_id=subscription_id
-                ).first()
-                if subscription:
-                    subscription.status = "canceled"
-                    subscription.canceled_at = datetime.datetime.now(
-                        datetime.timezone.utc
-                    )
-                    db.session.commit()
-                    logger.info(f"Subscription canceled: {subscription_id}")
-
+            subscription.status = "canceled"
+            subscription.canceled_at = datetime.datetime.now(datetime.timezone.utc)
         elif event_type == "customer.subscription.updated":
-            # Subscription updated (status change, plan change, etc.)
-            subscription_id = data.get("id")
-            status = data.get("status")
-            if subscription_id:
-                subscription = Subscription.query.filter_by(
-                    stripe_subscription_id=subscription_id
-                ).first()
-                if subscription:
-                    subscription.status = status
-                    if data.get("cancel_at_period_end"):
-                        subscription.canceled_at = datetime.datetime.now(
-                            datetime.timezone.utc
-                        )
+            subscription.status = data.get("status")
+            if data.get("cancel_at_period_end"):
+                subscription.canceled_at = datetime.datetime.now(datetime.timezone.utc)
+            elif data.get("cancel_at_period_end") is False and subscription.status != "canceled":
+                subscription.canceled_at = None
+            items = data.get("items", {}).get("data", [])
+            if items:
+                price = items[0].get("price", {})
+                trusted_plan = get_plan_for_stripe_price_id(price.get("id"))
+                if trusted_plan:
+                    subscription.tier, subscription.billing_interval = trusted_plan
+                else:
+                    subscription.tier = "free"
+                    subscription.billing_interval = "monthly"
+            if data.get("current_period_end"):
+                subscription.current_period_end = datetime.datetime.fromtimestamp(data["current_period_end"])
 
-                    # Update tier from current subscription items (handles scheduled downgrades)
-                    items = data.get("items", {}).get("data", [])
-                    if items:
-                        price_id = items[0].get("price", {}).get("id", "")
-                        trusted_plan = get_plan_for_stripe_price_id(price_id)
-                        subscription.tier = trusted_plan[0] if trusted_plan else "free"
-                        # Update billing interval
-                        interval = (
-                            items[0]
-                            .get("price", {})
-                            .get("recurring", {})
-                            .get("interval", "month")
-                        )
-                        subscription.billing_interval = trusted_plan[1] if trusted_plan else (
-                            "annual" if interval == "year" else "monthly"
-                        )
-
-                    # Update period end
-                    if data.get("current_period_end"):
-                        subscription.current_period_end = (
-                            datetime.datetime.fromtimestamp(data["current_period_end"])
-                        )
-
-                    db.session.commit()
-                    logger.info("Subscription update processed")
-
-    except Exception as e:
-        logger.error(f"Webhook processing error: {e}")
-        # Return 200 anyway to prevent Stripe retries
-        # Don't expose internal error details to external callers
+        if subscription:
+            subscription.stripe_last_event_created = event_created
+        db.session.commit()
         return jsonify({"received": True}), 200
-
-    return jsonify({"received": True}), 200
+    except IntegrityError:
+        db.session.rollback()
+        if event_id and StripeWebhookEvent.query.filter_by(event_id=event_id).first():
+            return jsonify({"received": True, "duplicate": True}), 200
+        logger.error("Stripe webhook transaction failed")
+        return jsonify({"error": "Webhook processing failed; Stripe may retry"}), 500
+    except Exception:
+        db.session.rollback()
+        logger.error("Stripe webhook transaction failed")
+        return jsonify({"error": "Webhook processing failed; Stripe may retry"}), 500
 
 
 @api_v2_bp.route("/me", methods=["GET", "PATCH"])

--- a/apps/server/config.py
+++ b/apps/server/config.py
@@ -120,7 +120,9 @@ REQUIRE_EMAIL_VERIFICATION = (
     is_saas() or os.environ.get("REQUIRE_EMAIL_VERIFICATION", "false").lower() == "true"
 )
 
-# Billing: only enabled for SaaS when Stripe is configured
+# Trial provisioning reflects billing intent, not temporary checkout readiness.
+# Preserve trials during incomplete Stripe configuration; never use this flag
+# to authorize payment operations or advertise a ready billing capability.
 ENABLE_BILLING = is_saas() and bool(os.environ.get("STRIPE_SECRET_KEY"))
 
 # Registration: enabled for SaaS, disabled by default for self-hosted
@@ -345,10 +347,16 @@ WEBAUTHN_EXPECTED_ORIGINS = [WEBAUTHN_ORIGIN, *WEBAUTHN_ANDROID_ORIGINS]
 
 def get_public_config():
     """Return configuration safe to expose to the frontend."""
+    from services.stripe_service import get_billing_readiness
+    billing_readiness = get_billing_readiness()
     enabled_providers = get_enabled_oauth_providers()
     return {
         "deployment_mode": DEPLOYMENT_MODE,
-        "billing_enabled": ENABLE_BILLING,
+        "billing_enabled": billing_readiness["billing_enabled"],
+        "billing_readiness": {
+            "ready": billing_readiness["ready"],
+            "reason": billing_readiness["reason"],
+        },
         "registration_enabled": ENABLE_REGISTRATION,
         "email_enabled": EMAIL_ENABLED,
         "email_verification_required": REQUIRE_EMAIL_VERIFICATION,
@@ -388,6 +396,8 @@ def get_mobile_capabilities(enabled_providers=None):
     """Return the pre-auth compatibility and feature envelope for mobile apps."""
     if enabled_providers is None:
         enabled_providers = get_enabled_oauth_providers()
+    from services.stripe_service import get_billing_readiness
+    billing_enabled = get_billing_readiness()["billing_enabled"]
 
     return {
         "mobile_contract_version": MOBILE_CONTRACT_VERSION,
@@ -404,7 +414,7 @@ def get_mobile_capabilities(enabled_providers=None):
             "oauth": bool(enabled_providers),
             "email_otp": ENABLE_2FA,
             "passkeys": ENABLE_PASSKEYS,
-            "billing": ENABLE_BILLING,
+            "billing": billing_enabled,
             "administration": True,
             "sharing": True,
             "settlements": True,

--- a/apps/server/db_migrations.py
+++ b/apps/server/db_migrations.py
@@ -1076,6 +1076,26 @@ def migrate_20260815_01_expand_oauth_state_transactions(db):
     db.session.commit()
 
 
+def migrate_20260907_01_stripe_webhook_reliability(db):
+    """Add Stripe webhook idempotency and ordering columns."""
+    inspector = inspect(db.engine)
+    if 'stripe_webhook_events' not in inspector.get_table_names():
+        db.session.execute(text('''
+            CREATE TABLE stripe_webhook_events (
+                id SERIAL PRIMARY KEY,
+                event_id VARCHAR(255) UNIQUE NOT NULL,
+                event_created INTEGER,
+                processed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        '''))
+    columns = {column['name'] for column in inspect(db.engine).get_columns('subscriptions')}
+    if 'stripe_last_event_created' not in columns:
+        db.session.execute(text(
+            'ALTER TABLE subscriptions ADD COLUMN stripe_last_event_created INTEGER'
+        ))
+    db.session.commit()
+
+
 # List of all migrations in order
 # Format: (version, description, function)
 MIGRATIONS = [
@@ -1111,6 +1131,7 @@ MIGRATIONS = [
     ('20260724_01', 'Add persisted per-user currency preference', migrate_20260724_01_add_user_currency),
     ('20260812_01', 'Create durable OAuth state replay ledger', migrate_20260812_01_create_oauth_state_uses),
     ('20260815_01', 'Store OAuth transactions server-side', migrate_20260815_01_expand_oauth_state_transactions),
+    ('20260907_01', 'Add Stripe webhook idempotency and ordering', migrate_20260907_01_stripe_webhook_reliability),
 ]
 
 

--- a/apps/server/models.py
+++ b/apps/server/models.py
@@ -454,6 +454,7 @@ class Subscription(db.Model):
 
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=lambda: datetime.now(timezone.utc))
+    stripe_last_event_created = db.Column(db.Integer, nullable=True)
 
     # Relationship
     user = db.relationship('User', backref=db.backref('subscription', uselist=False))
@@ -526,6 +527,15 @@ class Subscription(db.Model):
         now = datetime.now(timezone.utc).replace(tzinfo=None)
         period_end = self.current_period_end.replace(tzinfo=None) if self.current_period_end.tzinfo else self.current_period_end
         return now < period_end
+
+
+class StripeWebhookEvent(db.Model):
+    """Durable idempotency ledger for successfully handled Stripe events."""
+    __tablename__ = 'stripe_webhook_events'
+    id = db.Column(db.Integer, primary_key=True)
+    event_id = db.Column(db.String(255), unique=True, nullable=False)
+    event_created = db.Column(db.Integer, nullable=True)
+    processed_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
 
 
 class TelemetryLog(db.Model):

--- a/apps/server/services/stripe_service.py
+++ b/apps/server/services/stripe_service.py
@@ -65,7 +65,7 @@ def log_missing_billing_configuration():
     missing = get_missing_billing_configuration()
     now = time.monotonic()
     if missing and now - _last_readiness_log >= 60:
-        logger.warning("Stripe webhook unavailable; missing configuration: %s", ", ".join(missing))
+        logger.warning("Stripe billing unavailable: configuration is incomplete; check the operator runbook")
         _last_readiness_log = now
 
 

--- a/apps/server/services/stripe_service.py
+++ b/apps/server/services/stripe_service.py
@@ -3,6 +3,7 @@ Stripe billing service for subscription management.
 """
 import os
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,45 @@ try:
 except ImportError:
     get_stripe_price_id = lambda t, i: None
     STRIPE_PRICES = {}
+
+_last_readiness_log = 0.0
+
+
+def get_billing_readiness():
+    """Return sanitized, shared Stripe readiness and capability state."""
+    from config import DEPLOYMENT_MODE
+
+    missing = get_missing_billing_configuration()
+    ready = not missing
+    if DEPLOYMENT_MODE == "self-hosted":
+        return {"ready": ready, "billing_enabled": False, "reason": "self_hosted"}
+    return {"ready": ready, "billing_enabled": ready, "reason": "ready" if ready else "incomplete"}
+
+
+def get_missing_billing_configuration():
+    """Return non-secret configuration names for operator logs only."""
+    missing = []
+    if not STRIPE_AVAILABLE:
+        missing.append("sdk")
+    if not STRIPE_SECRET_KEY:
+        missing.append("api_key")
+    if not STRIPE_WEBHOOK_SECRET:
+        missing.append("webhook_secret")
+    for tier in ("basic", "plus"):
+        for interval in ("monthly", "annual"):
+            if not STRIPE_PRICES.get(tier, {}).get(interval):
+                missing.append(f"{tier}.{interval}")
+    return missing
+
+
+def log_missing_billing_configuration():
+    """Rate-limit sanitized missing-configuration logs for operators."""
+    global _last_readiness_log
+    missing = get_missing_billing_configuration()
+    now = time.monotonic()
+    if missing and now - _last_readiness_log >= 60:
+        logger.warning("Stripe webhook unavailable; missing configuration: %s", ", ".join(missing))
+        _last_readiness_log = now
 
 
 def init_stripe():
@@ -56,10 +96,8 @@ def create_checkout_session(
 
     Returns dict with 'url' for redirect or 'error' on failure.
     """
-    if not STRIPE_AVAILABLE or not STRIPE_SECRET_KEY:
+    if not get_billing_readiness()["billing_enabled"]:
         return {'error': 'Stripe not configured'}
-
-    # Get the price ID for the selected tier and interval
     price_id = get_stripe_price_id(tier, interval)
 
     if not price_id:
@@ -142,7 +180,7 @@ def construct_webhook_event(payload: bytes, sig_header: str) -> dict:
     Returns the event object or dict with 'error'.
     """
     if not STRIPE_AVAILABLE or not STRIPE_WEBHOOK_SECRET:
-        return {'error': 'Webhook secret not configured'}
+        return {'error': 'Webhook secret not configured', 'error_code': 'configuration'}
 
     stripe.api_key = STRIPE_SECRET_KEY
 
@@ -151,12 +189,12 @@ def construct_webhook_event(payload: bytes, sig_header: str) -> dict:
             payload, sig_header, STRIPE_WEBHOOK_SECRET
         )
         return event
-    except ValueError as e:
-        logger.error(f"Invalid webhook payload: {e}")
-        return {'error': 'Invalid payload'}
-    except stripe.error.SignatureVerificationError as e:
-        logger.error(f"Invalid webhook signature: {e}")
-        return {'error': 'Invalid signature'}
+    except ValueError:
+        logger.error("Invalid webhook payload received")
+        return {'error': 'Invalid payload', 'error_code': 'invalid_payload'}
+    except stripe.error.SignatureVerificationError:
+        logger.error("Invalid webhook signature received")
+        return {'error': 'Invalid signature', 'error_code': 'invalid_signature'}
 
 
 def get_subscription(subscription_id: str) -> dict:
@@ -180,8 +218,8 @@ def get_subscription(subscription_id: str) -> dict:
             'canceled_at': subscription.canceled_at,
             'price_id': price_id,
         }
-    except stripe.error.StripeError as e:
-        logger.error(f"Stripe subscription error: {e}")
+    except stripe.error.StripeError:
+        logger.error("Stripe subscription retrieval failed")
         return {'error': 'Unable to retrieve subscription details.'}
 
 

--- a/apps/server/services/telemetry.py
+++ b/apps/server/services/telemetry.py
@@ -148,7 +148,8 @@ class TelemetryCollector:
 
     def collect_metrics(self) -> Dict[str, Any]:
         """Collect all anonymous usage metrics."""
-        from config import DEPLOYMENT_MODE, ENABLE_BILLING
+        from config import DEPLOYMENT_MODE
+        from services.stripe_service import get_billing_readiness
 
         try:
             if not self.instance_id:
@@ -175,7 +176,7 @@ class TelemetryCollector:
             }
 
             # Add subscription metrics only for SaaS deployments
-            if ENABLE_BILLING and DEPLOYMENT_MODE == 'saas':
+            if get_billing_readiness()["billing_enabled"] and DEPLOYMENT_MODE == 'saas':
                 metrics["metrics"]["subscriptions"] = self._get_subscription_metrics()
 
             # Deployment identifiers are only used to alert the operator about

--- a/apps/server/tests/test_scan_remediations.py
+++ b/apps/server/tests/test_scan_remediations.py
@@ -291,6 +291,8 @@ def test_stripe_webhook_derives_entitlement_from_paid_price(
         app_module,
         "construct_webhook_event",
         lambda payload, signature: {
+            "id": "evt_checkout_entitlement",
+            "created": 1,
             "type": "checkout.session.completed",
             "data": {
                 "object": {

--- a/apps/server/tests/test_security_release.py
+++ b/apps/server/tests/test_security_release.py
@@ -148,7 +148,7 @@ def test_stripe_updated_uses_exact_configured_price(client, db_session, admin_us
     db_session.add(sub)
     db_session.commit()
     monkeypatch.setattr(config, 'STRIPE_PRICES', {'basic': {'monthly': 'price_opaque123'}})
-    monkeypatch.setattr(server, 'construct_webhook_event', lambda *args: {'type': 'customer.subscription.updated', 'data': {'object': {
+    monkeypatch.setattr(server, 'construct_webhook_event', lambda *args: {'id': 'evt_security', 'created': 1, 'type': 'customer.subscription.updated', 'data': {'object': {
         'id': 'sub_security', 'status': 'active', 'items': {'data': [{'price': {'id': price, 'recurring': {'interval': 'month'}}}]}}}})
     assert client.post('/api/v2/webhooks/stripe', headers={'Stripe-Signature': 'test'}, data='{}').status_code == 200
     db_session.refresh(sub)

--- a/apps/server/tests/test_stripe_checkout_safety.py
+++ b/apps/server/tests/test_stripe_checkout_safety.py
@@ -1,0 +1,29 @@
+"""Checkout association safety independent of provider networking."""
+import app as server
+from models import Subscription, StripeWebhookEvent
+
+
+def test_checkout_does_not_replace_a_different_subscription(client, db_session, regular_user, monkeypatch):
+    sub = Subscription(user_id=regular_user.id, stripe_subscription_id='sub_existing', status='active')
+    db_session.add(sub)
+    db_session.commit()
+    monkeypatch.setattr(server, 'construct_webhook_event', lambda *_: {
+        'id': 'evt_replace', 'created': 100, 'type': 'checkout.session.completed',
+        'data': {'object': {'subscription': 'sub_other', 'customer': 'cus_synthetic', 'metadata': {'user_id': str(regular_user.id)}}},
+    })
+    monkeypatch.setattr(server, 'get_subscription', lambda *_: {'price_id': 'price_basic', 'status': 'active', 'current_period_start': 1, 'current_period_end': 200})
+    monkeypatch.setattr(server, 'get_plan_for_stripe_price_id', lambda _: ('basic', 'monthly'))
+    response = client.post('/api/v2/webhooks/stripe', data=b'{}', headers={'Stripe-Signature': 'test'})
+    assert response.status_code == 500
+    db_session.refresh(sub)
+    assert sub.stripe_subscription_id == 'sub_existing'
+    assert StripeWebhookEvent.query.filter_by(event_id='evt_replace').count() == 0
+
+
+def test_checkout_requires_subscription_identity(client, monkeypatch):
+    monkeypatch.setattr(server, 'construct_webhook_event', lambda *_: {
+        'id': 'evt_invalid_checkout', 'created': 100, 'type': 'checkout.session.completed',
+        'data': {'object': {'metadata': {'user_id': '1'}}},
+    })
+    response = client.post('/api/v2/webhooks/stripe', data=b'{}', headers={'Stripe-Signature': 'test'})
+    assert response.status_code == 400

--- a/apps/server/tests/test_stripe_service.py
+++ b/apps/server/tests/test_stripe_service.py
@@ -36,6 +36,7 @@ def test_checkout_does_not_fall_back_to_legacy_price(monkeypatch):
     monkeypatch.setattr(stripe_service, "STRIPE_AVAILABLE", True)
     monkeypatch.setattr(stripe_service, "STRIPE_SECRET_KEY", "sk_test")
     monkeypatch.setattr(stripe_service, "STRIPE_PRICE_ID", "price_legacy")
+    monkeypatch.setattr(stripe_service, "get_billing_readiness", lambda: {"billing_enabled": True})
     monkeypatch.setattr(stripe_service, "get_stripe_price_id", lambda tier, interval: None)
 
     result = stripe_service.create_checkout_session(

--- a/apps/server/tests/test_stripe_webhook_concurrency.py
+++ b/apps/server/tests/test_stripe_webhook_concurrency.py
@@ -1,0 +1,45 @@
+"""PostgreSQL serialization and billing-readiness integration coverage."""
+from concurrent.futures import ThreadPoolExecutor
+import threading
+
+import app as server
+import config
+from models import db, StripeWebhookEvent, Subscription
+from services import stripe_service
+
+
+def test_concurrent_duplicate_delivery_commits_once(app, db_session, regular_user, monkeypatch):
+    db_session.add(Subscription(user_id=regular_user.id, stripe_subscription_id='sub_concurrent', status='active'))
+    db_session.commit()
+    barrier = threading.Barrier(2)
+
+    def verified(*_):
+        barrier.wait(timeout=10)
+        return {'id': 'evt_concurrent', 'created': 100, 'type': 'invoice.payment_failed',
+                'data': {'object': {'subscription': 'sub_concurrent'}}}
+
+    monkeypatch.setattr(server, 'construct_webhook_event', verified)
+
+    def deliver(_):
+        with app.app_context():
+            with app.test_client() as client:
+                response = client.post('/api/v2/webhooks/stripe', data=b'{}', headers={'Stripe-Signature': 'test'})
+                return response.status_code, response.get_json()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(deliver, range(2)))
+    assert [status for status, _ in results] == [200, 200]
+    assert sum(bool(body.get('duplicate')) for _, body in results) == 1
+    db.session.expire_all()
+    assert StripeWebhookEvent.query.filter_by(event_id='evt_concurrent').count() == 1
+    assert Subscription.query.filter_by(stripe_subscription_id='sub_concurrent').one().status == 'past_due'
+
+
+def test_checkout_and_capabilities_fail_closed_when_incomplete(client, admin_auth_headers, monkeypatch):
+    monkeypatch.setattr(config, 'DEPLOYMENT_MODE', 'saas')
+    monkeypatch.setattr(stripe_service, 'STRIPE_WEBHOOK_SECRET', None)
+    response = client.post('/api/v2/billing/create-checkout', json={'tier': 'basic', 'interval': 'monthly'}, headers=admin_auth_headers)
+    assert response.status_code == 503
+    assert config.get_public_config()['billing_enabled'] is False
+    assert config.get_mobile_capabilities()['features']['billing'] is False
+    assert 'error' in stripe_service.create_checkout_session(1, 'synthetic@example.invalid')

--- a/apps/server/tests/test_stripe_webhook_edges.py
+++ b/apps/server/tests/test_stripe_webhook_edges.py
@@ -1,0 +1,64 @@
+"""Regression coverage for webhook delivery edge cases."""
+import pytest
+
+import app as server
+from models import StripeWebhookEvent, Subscription
+
+
+def post_event(client):
+    return client.post('/api/v2/webhooks/stripe', data=b'{}', headers={'Stripe-Signature': 'test'})
+
+
+def test_subscription_update_preserves_scheduled_cancellation(client, db_session, regular_user, monkeypatch):
+    sub = Subscription(user_id=regular_user.id, stripe_subscription_id='sub_cancel', status='active')
+    db_session.add(sub)
+    db_session.commit()
+    monkeypatch.setattr(server, 'construct_webhook_event', lambda *_: {
+        'id': 'evt_cancel', 'created': 100, 'type': 'customer.subscription.updated',
+        'data': {'object': {'id': 'sub_cancel', 'status': 'active', 'cancel_at_period_end': True}},
+    })
+    assert post_event(client).status_code == 200
+    db_session.refresh(sub)
+    assert sub.canceled_at is not None
+
+
+def test_non_subscription_invoice_is_intentionally_ignored(client, db_session, monkeypatch):
+    monkeypatch.setattr(server, 'construct_webhook_event', lambda *_: {
+        'id': 'evt_standalone', 'created': 100, 'type': 'invoice.paid',
+        'data': {'object': {'subscription': None}},
+    })
+    assert post_event(client).status_code == 200
+    assert StripeWebhookEvent.query.filter_by(event_id='evt_standalone').count() == 1
+
+
+def test_equal_timestamp_reconciles_current_provider_state(client, db_session, regular_user, monkeypatch):
+    sub = Subscription(user_id=regular_user.id, stripe_subscription_id='sub_equal_live', status='active', stripe_last_event_created=100)
+    db_session.add(sub)
+    db_session.commit()
+    monkeypatch.setattr(server, 'construct_webhook_event', lambda *_: {
+        'id': 'evt_equal_live', 'created': 100, 'type': 'invoice.payment_failed',
+        'data': {'object': {'subscription': 'sub_equal_live'}},
+    })
+    monkeypatch.setattr(server, 'get_subscription', lambda *_: {
+        'status': 'canceled', 'price_id': 'price_basic', 'current_period_start': 1,
+        'current_period_end': 200, 'cancel_at_period_end': False, 'canceled_at': 150,
+    })
+    monkeypatch.setattr(server, 'get_plan_for_stripe_price_id', lambda _: ('basic', 'monthly'))
+    assert post_event(client).status_code == 200
+    db_session.refresh(sub)
+    assert sub.status == 'canceled'
+    assert StripeWebhookEvent.query.filter_by(event_id='evt_equal_live').count() == 1
+
+
+@pytest.mark.parametrize('kind', ['invoice.paid', 'invoice.payment_failed', 'checkout.session.completed'])
+def test_old_cross_type_event_cannot_reactivate_canceled_subscription(client, db_session, regular_user, monkeypatch, kind):
+    sub = Subscription(user_id=regular_user.id, stripe_subscription_id='sub_stale', status='canceled', stripe_last_event_created=200)
+    db_session.add(sub)
+    db_session.commit()
+    monkeypatch.setattr(server, 'construct_webhook_event', lambda *_: {
+        'id': 'evt_stale', 'created': 100, 'type': kind,
+        'data': {'object': {'subscription': 'sub_stale', 'metadata': {'user_id': str(regular_user.id)}}},
+    })
+    assert post_event(client).status_code == 200
+    db_session.refresh(sub)
+    assert sub.status == 'canceled'

--- a/apps/server/tests/test_stripe_webhook_reliability.py
+++ b/apps/server/tests/test_stripe_webhook_reliability.py
@@ -1,0 +1,177 @@
+import datetime
+
+import app as app_module
+import config
+from models import StripeWebhookEvent, Subscription
+from services import stripe_service
+
+
+def _event(event_id, event_type, created, obj):
+    return {
+        "id": event_id,
+        "type": event_type,
+        "created": created,
+        "data": {"object": obj},
+    }
+
+
+def test_saas_readiness_requires_all_stripe_inputs(monkeypatch):
+    monkeypatch.setattr(stripe_service, "STRIPE_AVAILABLE", True)
+    monkeypatch.setattr(stripe_service, "STRIPE_SECRET_KEY", "sk_test")
+    monkeypatch.setattr(stripe_service, "STRIPE_WEBHOOK_SECRET", "whsec_test")
+    monkeypatch.setattr(
+        stripe_service,
+        "STRIPE_PRICES",
+        {
+            "basic": {"monthly": "price_bm", "annual": "price_ba"},
+            "plus": {"monthly": "price_pm", "annual": None},
+        },
+    )
+    monkeypatch.setattr(config, "DEPLOYMENT_MODE", "saas")
+
+    readiness = stripe_service.get_billing_readiness()
+
+    assert readiness["ready"] is False
+    assert readiness["billing_enabled"] is False
+    assert "missing" not in readiness
+
+
+def test_self_hosted_billing_remains_disabled_even_when_stripe_is_ready(monkeypatch):
+    monkeypatch.setattr(stripe_service, "STRIPE_AVAILABLE", True)
+    monkeypatch.setattr(stripe_service, "STRIPE_SECRET_KEY", "sk_test")
+    monkeypatch.setattr(stripe_service, "STRIPE_WEBHOOK_SECRET", "whsec_test")
+    monkeypatch.setattr(
+        stripe_service,
+        "STRIPE_PRICES",
+        {tier: {interval: "price" for interval in ("monthly", "annual")} for tier in ("basic", "plus")},
+    )
+    monkeypatch.setattr(config, "DEPLOYMENT_MODE", "self-hosted")
+
+    readiness = stripe_service.get_billing_readiness()
+
+    assert readiness["ready"] is True
+    assert readiness["billing_enabled"] is False
+    assert readiness["reason"] == "self_hosted"
+    assert "missing" not in readiness
+
+
+def test_construct_webhook_distinguishes_valid_and_invalid_signature(monkeypatch):
+    monkeypatch.setattr(stripe_service, "STRIPE_AVAILABLE", True)
+    monkeypatch.setattr(stripe_service, "STRIPE_WEBHOOK_SECRET", "whsec_test")
+    monkeypatch.setattr(stripe_service.stripe.Webhook, "construct_event", lambda *args: {"id": "evt_valid"})
+    assert stripe_service.construct_webhook_event(b"{}", "sig")["id"] == "evt_valid"
+
+    def invalid(*args):
+        raise stripe_service.stripe.error.SignatureVerificationError("bad", b"{}")
+
+    monkeypatch.setattr(stripe_service.stripe.Webhook, "construct_event", invalid)
+    assert stripe_service.construct_webhook_event(b"{}", "sig") == {
+        "error": "Invalid signature",
+        "error_code": "invalid_signature",
+    }
+
+
+def test_webhook_missing_configuration_is_service_unavailable(client, monkeypatch):
+    monkeypatch.setattr(app_module, "construct_webhook_event", lambda *_: {"error": "Webhook secret not configured"})
+
+    response = client.post("/api/v2/webhooks/stripe", data=b"{}", headers={"Stripe-Signature": "sig"})
+
+    assert response.status_code == 503
+
+
+def test_webhook_processing_failure_is_retryable_and_rolls_back(client, app, db_session, regular_user, monkeypatch):
+    subscription = Subscription(user_id=regular_user.id, stripe_subscription_id="sub_missing", status="active")
+    db_session.add(subscription)
+    db_session.commit()
+    event = _event("evt_failure", "invoice.paid", 100, {"subscription": "sub_missing"})
+    monkeypatch.setattr(app_module, "construct_webhook_event", lambda *_: event)
+    monkeypatch.setattr(app_module, "get_subscription", lambda *_: (_ for _ in ()).throw(RuntimeError("stripe down")))
+
+    response = client.post("/api/v2/webhooks/stripe", data=b"{}", headers={"Stripe-Signature": "sig"})
+
+    assert response.status_code == 500
+    with app.app_context():
+        assert StripeWebhookEvent.query.filter_by(event_id="evt_failure").count() == 0
+
+
+def test_webhook_duplicate_event_is_acknowledged_once(client, app, db_session, regular_user, monkeypatch):
+    db_session.add(Subscription(user_id=regular_user.id, stripe_subscription_id="sub_missing", status="active"))
+    db_session.commit()
+    event = _event("evt_duplicate", "invoice.payment_failed", 100, {"subscription": "sub_missing"})
+    monkeypatch.setattr(app_module, "construct_webhook_event", lambda *_: event)
+
+    first = client.post("/api/v2/webhooks/stripe", data=b"{}", headers={"Stripe-Signature": "sig"})
+    second = client.post("/api/v2/webhooks/stripe", data=b"{}", headers={"Stripe-Signature": "sig"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    with app.app_context():
+        assert StripeWebhookEvent.query.filter_by(event_id="evt_duplicate").count() == 1
+
+
+def test_subscription_events_do_not_regress_on_out_of_order_delivery(client, app, db_session, regular_user, monkeypatch):
+    subscription = Subscription(user_id=regular_user.id, stripe_subscription_id="sub_order", status="active")
+    db_session.add(subscription)
+    db_session.commit()
+    events = iter([
+        _event("evt_new", "customer.subscription.updated", 200, {"id": "sub_order", "status": "canceled"}),
+        _event("evt_old", "customer.subscription.updated", 100, {"id": "sub_order", "status": "active"}),
+    ])
+    monkeypatch.setattr(app_module, "construct_webhook_event", lambda *_: next(events))
+
+    for _ in range(2):
+        response = client.post("/api/v2/webhooks/stripe", data=b"{}", headers={"Stripe-Signature": "sig"})
+        assert response.status_code == 200
+
+    with app.app_context():
+        assert Subscription.query.filter_by(stripe_subscription_id="sub_order").one().status == "canceled"
+
+
+def test_supported_event_without_identity_is_rejected_before_ledger(client, app, monkeypatch):
+    monkeypatch.setattr(app_module, "construct_webhook_event", lambda *_: {
+        "type": "invoice.payment_failed", "created": 10,
+        "data": {"object": {"subscription": "sub_invalid"}},
+    })
+    response = client.post("/api/v2/webhooks/stripe", data=b"{}", headers={"Stripe-Signature": "sig"})
+    assert response.status_code == 400
+
+
+def test_missing_local_subscription_is_retryable(client, app, monkeypatch):
+    monkeypatch.setattr(app_module, "construct_webhook_event", lambda *_: _event(
+        "evt_missing_local", "invoice.payment_failed", 10, {"subscription": "sub_late"}
+    ))
+    response = client.post("/api/v2/webhooks/stripe", data=b"{}", headers={"Stripe-Signature": "sig"})
+    assert response.status_code == 500
+    with app.app_context():
+        assert StripeWebhookEvent.query.filter_by(event_id="evt_missing_local").first() is None
+
+
+def test_equal_timestamp_distinct_event_fails_retryably(client, app, db_session, regular_user, monkeypatch):
+    db_session.add(Subscription(user_id=regular_user.id, stripe_subscription_id="sub_equal", status="canceled"))
+    db_session.commit()
+    events = iter([
+        _event("evt_equal_one", "customer.subscription.deleted", 50, {"id": "sub_equal"}),
+        _event("evt_equal_two", "invoice.payment_failed", 50, {"subscription": "sub_equal"}),
+    ])
+    monkeypatch.setattr(app_module, "construct_webhook_event", lambda *_: next(events))
+    assert client.post("/api/v2/webhooks/stripe", data=b"{}", headers={"Stripe-Signature": "sig"}).status_code == 200
+    assert client.post("/api/v2/webhooks/stripe", data=b"{}", headers={"Stripe-Signature": "sig"}).status_code == 500
+
+
+def test_commit_failure_rolls_back_ledger_and_business_change(client, app, db_session, regular_user, monkeypatch):
+    db_session.add(Subscription(user_id=regular_user.id, stripe_subscription_id="sub_commit", status="active"))
+    db_session.commit()
+    monkeypatch.setattr(app_module, "construct_webhook_event", lambda *_: _event(
+        "evt_commit_fail", "invoice.payment_failed", 60, {"subscription": "sub_commit"}
+    ))
+    original_commit = db_session.commit
+    def fail_commit():
+        raise RuntimeError("database unavailable")
+    monkeypatch.setattr(db_session, "commit", fail_commit)
+    response = client.post("/api/v2/webhooks/stripe", data=b"{}", headers={"Stripe-Signature": "sig"})
+    assert response.status_code == 500
+    monkeypatch.setattr(db_session, "commit", original_commit)
+    db_session.rollback()
+    with app.app_context():
+        assert StripeWebhookEvent.query.filter_by(event_id="evt_commit_fail").first() is None
+        assert Subscription.query.filter_by(stripe_subscription_id="sub_commit").one().status == "active"

--- a/docs/stripe-webhook-operations.md
+++ b/docs/stripe-webhook-operations.md
@@ -1,0 +1,26 @@
+# Stripe billing readiness and webhook recovery
+
+SaaS billing is advertised as enabled only when the Stripe SDK, API key, webhook secret, and all four configured prices (Basic/Plus, monthly/annual) are present. The public `/api/v2/config` response includes only generic readiness state; missing component names are logged for operators without exposing configuration details. Self-hosted deployments keep billing disabled even if Stripe variables happen to be present.
+
+A SaaS checkout request returns `503` while readiness is incomplete. Correct the operator configuration and restart the server. Trial provisioning retains the existing SaaS/API-key policy independently of payment readiness. A missing webhook secret/configuration also returns `503`. Invalid signatures or malformed payloads return `400`. Both are failed deliveries; do not assume Stripe stops retries solely because a response is `400`.
+
+Webhook event IDs are stored in a durable unique ledger. Retries and concurrent duplicates are acknowledged without applying business effects twice. Subscription-bearing events are serialized per subscription; checkout completions additionally serialize per user. Older deliveries do not overwrite newer state. Standalone invoice events are deliberately acknowledged without subscription changes. Processing or commit failures roll back the ledger and local changes and return `500`, so Stripe can retry.
+
+## Recovery
+
+1. Check the sanitized readiness payload from `/api/v2/config` and server logs for the missing component names.
+2. Correct the relevant environment variables, including every offered price and the endpoint signing secret, then restart the application.
+3. Confirm readiness and monitor the Stripe Dashboard's webhook delivery status.
+4. For a processing failure, inspect application logs and database state, correct the underlying issue, and use Stripe Dashboard's manual **Resend** for the affected event.
+
+There is no automatic production replay. Operators must review the event and use Stripe's controlled resend after recovery. Every supported verified event must contain an event ID and creation timestamp. Distinct events created in the same second reconcile against the current Stripe subscription under the transaction lock; failed retrieval or an unknown price leaves the event retryable rather than guessing its order.
+
+## Upgrade and operational boundaries
+
+Migration `20260907_01` adds `stripe_webhook_events` and the subscription ordering timestamp through the existing startup migration mechanism. The ledger contains event identifiers and timestamps, not webhook payloads. It covers deliveries handled after this upgrade, not historical events previously acknowledged by older code. No automatic ledger pruning is performed.
+
+A webhook referencing a subscription not yet present locally returns `500` so a later checkout delivery can establish the association first. If the account was permanently deleted, no user is recreated; operators must distinguish deletion from delayed delivery before resending.
+
+A checkout for a different Stripe subscription cannot silently overwrite an existing local subscription association, even after cancellation. This conflict returns `500` and requires operator reconciliation of the old/new Stripe subscriptions and local association before resend. Automatic subscription replacement, refunding duplicate purchases, and production data repair are outside this change. Monitor failed deliveries so these conflicts do not go unnoticed.
+
+Presence checks cannot prove that secrets/prices belong to the intended Stripe account, that Stripe can reach the endpoint, or that the configured Stripe API version matches the event payload. Validate those boundaries with a Stripe test-mode end-to-end delivery before production promotion. No live Stripe event was replayed as part of local verification.

--- a/docs/stripe-webhook-operations.md
+++ b/docs/stripe-webhook-operations.md
@@ -1,6 +1,6 @@
 # Stripe billing readiness and webhook recovery
 
-SaaS billing is advertised as enabled only when the Stripe SDK, API key, webhook secret, and all four configured prices (Basic/Plus, monthly/annual) are present. The public `/api/v2/config` response includes only generic readiness state; missing component names are logged for operators without exposing configuration details. Self-hosted deployments keep billing disabled even if Stripe variables happen to be present.
+SaaS billing is advertised as enabled only when the Stripe SDK, API key, webhook secret, and all four configured prices (Basic/Plus, monthly/annual) are present. The public `/api/v2/config` response includes only generic readiness state; operator logs use a fixed warning without configuration-derived values. Self-hosted deployments keep billing disabled even if Stripe variables happen to be present.
 
 A SaaS checkout request returns `503` while readiness is incomplete. Correct the operator configuration and restart the server. Trial provisioning retains the existing SaaS/API-key policy independently of payment readiness. A missing webhook secret/configuration also returns `503`. Invalid signatures or malformed payloads return `400`. Both are failed deliveries; do not assume Stripe stops retries solely because a response is `400`.
 
@@ -8,7 +8,7 @@ Webhook event IDs are stored in a durable unique ledger. Retries and concurrent 
 
 ## Recovery
 
-1. Check the sanitized readiness payload from `/api/v2/config` and server logs for the missing component names.
+1. Check the sanitized readiness payload from `/api/v2/config` and the fixed incomplete-configuration warning in server logs. Privately verify the configuration components listed above; do not print credentials.
 2. Correct the relevant environment variables, including every offered price and the endpoint signing secret, then restart the application.
 3. Confirm readiness and monitor the Stripe Dashboard's webhook delivery status.
 4. For a processing failure, inspect application logs and database state, correct the underlying issue, and use Stripe Dashboard's manual **Resend** for the affected event.


### PR DESCRIPTION
## Summary
- Gate checkout and advertised capabilities on Stripe readiness while preserving SaaS trial provisioning.
- Return retryable failures for webhook configuration and processing errors; roll back ledger and business changes together.
- Add durable event deduplication, subscription/user serialization, ordering protection, and same-second reconciliation.
- Preserve cancellation updates and ignore standalone invoices safely.
- Document migration 20260907_01 and controlled recovery, including conflicting subscription associations.

## Verification
- Backend SaaS: 403 passed, 3 skipped.
- Backend self-hosted: 389 passed, 17 skipped.
- Web: 75 tests, lint, production build and audit passed.
- Mobile: 284 tests and full check passed; audit passed with existing exceptions.
- Bandit and backend dependency audit passed.
- PostgreSQL concurrent duplicate test and migration schema read-back passed.

## Deployment boundary
Production deployment and live Stripe test-mode end-to-end delivery are pending. No production migration or replay has been performed. Existing different subscription associations fail safely and require operator reconciliation.

Related to #118. Leave the issue open until deployment is verified.